### PR TITLE
docs: document lazyjj in the README SCM tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Dev environment preference for the Ubuntu Linux distribution.
 - [gti](https://r-wos.org/hacks/gti)
 - [Jujutsu](https://jj-vcs.dev/)
 - [lazygit](https://github.com/jesseduffield/lazygit)
+- [lazyjj](https://github.com/Cretezy/lazyjj)
 - [Apache Subversion](https://subversion.apache.org/)
 
 ### Shell utilities


### PR DESCRIPTION
## Summary

Add `lazyjj` to the README "SCM tools" list. `lib/Brewfile` installs it,
but it was undocumented unlike its siblings `Jujutsu` and `lazygit`.

## Validation

- `npx markdownlint-cli2 "README.md"` — 0 errors
- `npx cspell lint "**"` — 0 issues

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference to a new SCM tool in the package list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->