### PR TITLE
chore: remove the unused OS variable from the setup script

### DIFF
--- a/setup
+++ b/setup
@@ -5,8 +5,6 @@
 set -eu
 cd "$(cd "$(dirname "$0")"; pwd)"
 
-OS="$(uname -s)"
-
 if ! (command -v apt-get >/dev/null 2>&1)
 then
   USE_VIRTUAL=1


### PR DESCRIPTION
## Summary

Remove the unused `OS="$(uname -s)"` assignment from `setup`. It was dead
code flagged by `shellcheck` as `SC2034`; nothing reads it.

## Validation

- `grep OS= setup` — no matches
- `sh -n setup` — no syntax errors
- `shellcheck setup` — no longer reports `SC2034`

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
