### PR TITLE
ci: cancel superseded lint workflow runs with a concurrency group

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Linting workflow
 on:
   push:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Summary

Add a `concurrency` group to `.github/workflows/lint.yml` so superseded
in-progress lint runs on the same ref are cancelled.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## Validation

- YAML parses (js-yaml); `concurrency.cancel-in-progress: true`
- existing `lint` job and its 3 steps unchanged
- `npx cspell lint "**"` — 0 issues

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
