### PR TITLE
ci: lint shell scripts with shellcheck

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -37,6 +37,7 @@ words:
   - kuroné
   - larstobi
   - lazyjj
+  - ludeeus
   - nyancat
   - ollama
   - pylint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v23
       - name: Run shellcheck
+        # Lints setup and nuke (detected via their #!/bin/sh shebang) and
+        # lib/*.sh; .githooks is upstream-managed template code and excluded.
         uses: ludeeus/action-shellcheck@2.0.0
         with:
           ignore_paths: .githooks

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,3 +16,7 @@ jobs:
         uses: streetsidesoftware/cspell-action@v8
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v23
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          ignore_paths: .githooks

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -27,11 +27,13 @@ npx -y markdownlint-cli2 "**/*.md" && npx -y cspell lint "**" --no-progress
 npx -y markdownlint-cli2 --fix "**/*.md" && npx -y markdownlint-cli2 "**/*.md" && npx -y cspell lint "**" --no-progress
 ```
 
-These commands mirror the repository CI defined in
-[`.github/workflows/lint.yml`](../.github/workflows/lint.yml) (cspell and
-markdownlint). `shellcheck` is intentionally omitted because it is not part
-of the current CI gate; add it to these commands if shell linting becomes a
-required check.
+These commands run `markdownlint` and `cspell`, matching the checks that
+most IDD issues exercise. The `lint` workflow
+([`.github/workflows/lint.yml`](../.github/workflows/lint.yml)) additionally
+runs `shellcheck` on the shell scripts; it is kept out of the local validate
+commands above (which target the markdown and text edits IDD issues usually
+make). Run `shellcheck setup nuke lib/*.sh` directly when changing shell
+scripts.
 
 ## Policy decisions
 

--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -5,6 +5,7 @@
 set -eu
 cd "$(cd "$(dirname "$0")"; pwd)/.."
 
+# /etc/os-release is an external system file ShellCheck cannot follow.
 # shellcheck source=/dev/null
 . /etc/os-release
 

--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -5,6 +5,7 @@
 set -eu
 cd "$(cd "$(dirname "$0")"; pwd)/.."
 
+# shellcheck source=/dev/null
 . /etc/os-release
 
 OLDS="$(dpkg --get-selections docker.io docker-compose docker-compose-v2 docker-doc podman-docker containerd runc | cut -f1)"

--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -9,6 +9,7 @@ if [ ! -d "/home/linuxbrew/.linuxbrew" ]
 then
   curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash -
   echo >> "${HOME}/.bashrc"
+  # shellcheck disable=SC2016
   echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> "${HOME}/.bashrc"
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 fi

--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -9,6 +9,8 @@ if [ ! -d "/home/linuxbrew/.linuxbrew" ]
 then
   curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash -
   echo >> "${HOME}/.bashrc"
+  # Single quotes are intentional: the literal line is appended to ~/.bashrc
+  # to be evaluated at each shell startup, not expanded here.
   # shellcheck disable=SC2016
   echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> "${HOME}/.bashrc"
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/lib/locale.sh
+++ b/lib/locale.sh
@@ -14,6 +14,8 @@ sudo ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 echo 'Asia/Tokyo' | sudo tee /etc/timezone
 
 # Set keyboard layout
+# The input redirect reads a repo-local, user-readable file, so sudo not
+# affecting the redirect is harmless here.
 # shellcheck disable=SC2024
 sudo tee /etc/default/keyboard < etc/default/keyboard
 sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure -f noninteractive keyboard-configuration

--- a/lib/locale.sh
+++ b/lib/locale.sh
@@ -14,5 +14,6 @@ sudo ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 echo 'Asia/Tokyo' | sudo tee /etc/timezone
 
 # Set keyboard layout
+# shellcheck disable=SC2024
 sudo tee /etc/default/keyboard < etc/default/keyboard
 sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure -f noninteractive keyboard-configuration

--- a/lib/pwsh.sh
+++ b/lib/pwsh.sh
@@ -5,6 +5,7 @@
 set -eu
 cd "$(cd "$(dirname "$0")"; pwd)/.."
 
+# /etc/os-release is an external system file ShellCheck cannot follow.
 # shellcheck source=/dev/null
 . /etc/os-release
 

--- a/lib/pwsh.sh
+++ b/lib/pwsh.sh
@@ -5,6 +5,7 @@
 set -eu
 cd "$(cd "$(dirname "$0")"; pwd)/.."
 
+# shellcheck source=/dev/null
 . /etc/os-release
 
 curl -fsSL "https://packages.microsoft.com/config/${ID}/${VERSION_ID}/packages-microsoft-prod.deb" \

--- a/setup
+++ b/setup
@@ -14,6 +14,7 @@ fi
 
 if [ -e "/etc/os-release" ]
 then
+  # /etc/os-release is an external system file ShellCheck cannot follow.
   # shellcheck source=/dev/null
   . /etc/os-release
   if [ "${ID}" != "ubuntu" ]

--- a/setup
+++ b/setup
@@ -14,6 +14,7 @@ fi
 
 if [ -e "/etc/os-release" ]
 then
+  # shellcheck source=/dev/null
   . /etc/os-release
   if [ "${ID}" != "ubuntu" ]
   then


### PR DESCRIPTION
## Summary

Add a `shellcheck` step to the `lint` workflow to statically check the
project's shell scripts (`setup`, `nuke`, `lib/*.sh`). The
upstream-managed `.githooks/` is excluded via `ignore_paths`.

Intentional / external-source findings are silenced with narrowly-scoped
directives instead of broad suppression:

- `# shellcheck source=/dev/null` — external `. /etc/os-release` in
  `setup`, `lib/docker.sh`, `lib/pwsh.sh`
- `# shellcheck disable=SC2016` — intentional single-quoted brew shellenv
  line in `lib/homebrew.sh`
- `# shellcheck disable=SC2024` — repo-local input redirect in
  `lib/locale.sh`

## Validation

- `shellcheck setup nuke lib/*.sh` — 0 findings
- `npx markdownlint-cli2 "**/*.md"` — 0 errors
- `npx cspell lint "**"` — 0 issues (added `ludeeus` to the dictionary)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated spell checker configuration to recognize additional terminology.
  * Added shell script linting workflow step to the CI/CD pipeline.
  * Added linting directives across shell scripts to improve code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->