### PR TITLE
build: add Terraform updates to the Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     package-ecosystem: github-actions
     schedule:
       interval: monthly
+  - directory: /
+    labels:
+      - dependencies
+    package-ecosystem: terraform
+    schedule:
+      interval: monthly


### PR DESCRIPTION
## Summary

Add a `terraform` ecosystem entry to `.github/dependabot.yml` so the
`larstobi/multipass` provider pinned in `main.tf` gets automated update
PRs, just like the GitHub Actions are already watched.

## Validation

- YAML valid (js-yaml); `updates` ecosystems = `[github-actions, terraform]`
- new entry matches the existing one's `directory: /`, `dependencies`
  label, and `monthly` schedule
- `npx cspell lint "**"` — 0 issues

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Enhanced automated dependency management configuration for infrastructure maintenance.

**Note:** This release contains internal infrastructure improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->