### PR TITLE
chore: normalize text file line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Normalize text files to LF in the repo and on checkout; Git auto-detects
+# binary files and leaves them untouched.
+* text=auto eol=lf
+
 .coderabbit.yaml export-ignore
 .git* export-ignore
 .imgbotconfig export-ignore


### PR DESCRIPTION
## Summary

Add `* text=auto eol=lf` to `.gitattributes` so Git normalizes text files
to LF in the repository and on checkout, protecting the POSIX/bash scripts
from accidental CRLF. Binary files are auto-detected and left untouched;
the existing `export-ignore` rules are preserved.

## Validation

- `git check-attr text eol -- setup …` → `text: auto`, `eol: lf`
- `git add --renormalize .` stages only `.gitattributes` (all tracked files
  are already LF, so this is a safe no-op renormalization)
- `npx cspell lint "**"` — 0 issues

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
