### PR TITLE
build: recommend ShellCheck and Terraform VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,9 @@
   "recommendations": [
     "davidanson.vscode-markdownlint",
     "editorconfig.editorconfig",
+    "hashicorp.terraform",
     "redhat.vscode-yaml",
-    "streetsidesoftware.code-spell-checker"
+    "streetsidesoftware.code-spell-checker",
+    "timonwong.shellcheck"
   ]
 }


### PR DESCRIPTION
## Summary

Recommend the **ShellCheck** (`timonwong.shellcheck`) and **Terraform**
(`hashicorp.terraform`) VS Code extensions so the editor recommendations
match the repository's toolchain — `shellcheck` now runs in CI and the
repo uses Terraform (`main.tf`, `.terraform.lock.hcl`).

## Validation

- `.vscode/extensions.json` is valid JSON; `recommendations` stays sorted
- both new extensions present alongside the existing four
- `npx cspell lint "**"` — 0 issues

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VS Code extension recommendations to include tools for infrastructure-as-code and shell script validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->