### PR TITLE
fix: remove old Docker packages individually in docker.sh

### DIFF
--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -10,7 +10,14 @@ cd "$(cd "$(dirname "$0")"; pwd)/.."
 . /etc/os-release
 
 OLDS="$(dpkg --get-selections docker.io docker-compose docker-compose-v2 docker-doc podman-docker containerd runc | cut -f1)"
-sudo apt remove -y "${OLDS}" || true
+if [ -n "${OLDS}" ]
+then
+  # Word-splitting is intentional so each old package is passed to apt as
+  # its own argument. The script is POSIX sh, so a bash array is not
+  # available.
+  # shellcheck disable=SC2086
+  sudo apt remove -y ${OLDS} || true
+fi
 sudo install -m 0755 -d /etc/apt/keyrings
 GPG_URL="https://download.docker.com/linux/${ID}/gpg"
 sudo curl -fsSL "${GPG_URL}" -o /etc/apt/keyrings/docker.asc


### PR DESCRIPTION
## Summary

Fix the pre-install cleanup in `lib/docker.sh`. Quoting the
newline-separated list as `apt remove -y "${OLDS}"` passed it to apt as a
single (invalid) argument, so when more than one old Docker package was
installed the removal silently failed (`|| true`) and nothing was removed.

The list is now word-split so each package is its own argument (POSIX sh —
no bash array), guarded for the empty case, with the intentional
word-splitting scoped by a justified `# shellcheck disable=SC2086`.

## Validation

- `shellcheck setup nuke lib/*.sh` — clean
- `sh -n lib/docker.sh` — no syntax errors
- still POSIX `sh` (no bashisms/arrays)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker container/runtime package removal during setup to prevent unintended behavior when no previous packages are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->