### PR TITLE
ci: harden workflows — pin actions to commit SHAs and add actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+# Declare the project's GitHub-hosted runner label so actionlint does not
+# report it as an unknown runner label.
+self-hosted-runner:
+  labels:
+    - ubuntu-slim

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,7 @@
-# Declare the project's GitHub-hosted runner label so actionlint does not
-# report it as an unknown runner label.
+# actionlint validates `runs-on` labels against its set of known runner
+# labels. `ubuntu-slim` is not in that set, so register it here.
+# `self-hosted-runner.labels` is actionlint's documented mechanism for
+# declaring additional accepted labels, regardless of the key name.
 self-hosted-runner:
   labels:
     - ubuntu-slim

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,14 +11,16 @@ jobs:
   lint:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Run cspell
-        uses: streetsidesoftware/cspell-action@v8
+        uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23
       - name: Run shellcheck
         # Lints setup and nuke (detected via their #!/bin/sh shebang) and
         # lib/*.sh; .githooks is upstream-managed template code and excluded.
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           ignore_paths: .githooks
+      - name: Run actionlint
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Run cspell
         uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8
       - name: Run markdownlint

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
         with:
           days-before-close: 14
           days-before-stale: 60


### PR DESCRIPTION
## Summary

Harden the GitHub Actions workflows (cohesive change — both edits touch the
same files and the new lint step's action is itself pinned):

1. **Pin every action to a commit SHA** with a `# version` comment so the
   version stays readable and Dependabot keeps updating both:
   - `actions/checkout` → `df4cb1c` # v6
   - `streetsidesoftware/cspell-action` → `de2a73e` # v8
   - `DavidAnson/markdownlint-cli2-action` → `ded1f94` # v23
   - `ludeeus/action-shellcheck` → `00cae50` # 2.0.0
   - `actions/stale` → `eb5cf3a` # v10
   - `raven-actions/actionlint` → `205b530` # v2.1.2 (new)
2. **Add an `actionlint` step** to the lint workflow that statically
   validates the workflow files, with `.github/actionlint.yaml` declaring
   the `ubuntu-slim` runner label.

## Validation

- `actionlint` (1.7.12) on the updated workflows — 0 findings
- all 6 `uses:` refs SHA-pinned (40-hex) with version comments; 0 bare tags
- `.github/actionlint.yaml` valid YAML
- `npx cspell lint "**"` — 0 issues; `npx markdownlint-cli2 "**/*.md"` — 0 errors

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI lint and maintenance workflows to use pinned commit references instead of floating action tags.
  * Adjusted CI configuration to recognize the `ubuntu-slim` self-hosted runner label, avoiding unknown-runner validation issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->