### PR TITLE
feat: add opt-in --desktop flag with environment and GPU detection

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -49,3 +49,4 @@ words:
   - xkbmodel
   - xkboptions
   - xkbvariant
+  - xrdp

--- a/lib/desktop.sh
+++ b/lib/desktop.sh
@@ -52,32 +52,41 @@ detect_environment() {
 
 # Echo one of: nvidia | amd | intel | none. Never errors, even with no GPU and
 # no detection tools installed. PCI vendor IDs: 0x10de NVIDIA, 0x1002 AMD/ATI,
-# 0x8086 Intel. Only display devices are inspected (the DRM card nodes, and the
+# 0x8086 Intel. Only display devices are inspected (the DRM card nodes plus the
 # VGA/3D/Display lines from lspci) so unrelated PCI devices such as NICs or the
-# chipset cannot be mistaken for a GPU. A discrete NVIDIA GPU is preferred over
-# an integrated one because it is the device usable for GPU streaming.
+# chipset cannot be mistaken for a GPU. Vendors are tested in priority order
+# (NVIDIA, then AMD, then Intel) across both sources, so a discrete GPU is
+# preferred over an integrated one — the discrete device is the one usable for
+# GPU streaming. NVIDIA requires a real device (a 0x10de display node, a working
+# nvidia-smi, an /dev/nvidia0 node, or an lspci display line), not merely the
+# presence of the nvidia-smi binary.
 detect_gpu_vendor() {
   ids=""
   for f in /sys/class/drm/card*/device/vendor; do
     [ -r "$f" ] || continue
     ids="${ids} $(cat "$f" 2>/dev/null || true)"
   done
-  case " ${ids} " in
-  *0x10de*) echo nvidia; return ;;
-  esac
-  if command -v nvidia-smi >/dev/null 2>&1 || [ -e /dev/nvidia0 ]; then
+  gpus=""
+  if command -v lspci >/dev/null 2>&1; then
+    gpus="$(lspci 2>/dev/null | grep -iE 'vga|3d|display' || true)"
+  fi
+
+  if printf '%s' " ${ids} " | grep -q '0x10de' ||
+    { command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; } ||
+    [ -e /dev/nvidia0 ] ||
+    printf '%s\n' "${gpus}" | grep -qiE 'nvidia'; then
     echo nvidia
     return
   fi
-  case " ${ids} " in
-  *0x1002*) echo amd; return ;;
-  *0x8086*) echo intel; return ;;
-  esac
-  if command -v lspci >/dev/null 2>&1; then
-    gpus="$(lspci 2>/dev/null | grep -iE 'vga|3d|display' || true)"
-    if printf '%s\n' "${gpus}" | grep -qiE 'nvidia'; then echo nvidia; return; fi
-    if printf '%s\n' "${gpus}" | grep -qiE 'amd|ati|radeon'; then echo amd; return; fi
-    if printf '%s\n' "${gpus}" | grep -qiE 'intel'; then echo intel; return; fi
+  if printf '%s' " ${ids} " | grep -q '0x1002' ||
+    printf '%s\n' "${gpus}" | grep -qiE 'amd|ati|radeon'; then
+    echo amd
+    return
+  fi
+  if printf '%s' " ${ids} " | grep -q '0x8086' ||
+    printf '%s\n' "${gpus}" | grep -qiE 'intel'; then
+    echo intel
+    return
   fi
   echo none
 }

--- a/lib/desktop.sh
+++ b/lib/desktop.sh
@@ -1,0 +1,145 @@
+#!/bin/sh
+# -*- mode: sh -*-
+# vim: set ft=sh :
+
+set -eu
+cd "$(cd "$(dirname "$0")"; pwd)/.."
+
+# Opt-in desktop layer foundation (issue #28). This script performs only
+# environment/GPU detection and prints a dry-run plan; the actual install
+# stages are filled in by sibling issues (#29 XFCE + xrdp, #30 Sunshine,
+# #31 GPU driver + virtual display). The default CLI setup never calls it.
+
+DESKTOP_DRY_RUN="${DESKTOP_DRY_RUN:-0}"
+
+log() { printf '[desktop] %s\n' "$*"; }
+plan() { printf '[desktop:plan] %s\n' "$*"; }
+
+# Return success when running under WSL2. Several independent signals are
+# checked so a missing ${WSL_DISTRO_NAME} (custom init, root sessions) cannot
+# misclassify a WSL2 host as bare-metal and trigger a Linux GPU driver install,
+# which would break WSLg (the Windows-side driver exposed through /dev/dxg).
+is_wsl2() {
+  if [ -n "${WSL_DISTRO_NAME:-}" ]; then return 0; fi
+  if [ -e /run/WSL ]; then return 0; fi
+  if [ -e /proc/sys/fs/binfmt_misc/WSLInterop ]; then return 0; fi
+  if [ -r /proc/sys/kernel/osrelease ] &&
+    grep -qiE 'microsoft|wsl' /proc/sys/kernel/osrelease; then return 0; fi
+  if [ -r /proc/version ] &&
+    grep -qiE 'microsoft|wsl' /proc/version; then return 0; fi
+  return 1
+}
+
+# Echo one of: wsl2 | baremetal | unsupported.
+detect_environment() {
+  if is_wsl2; then echo wsl2; return; fi
+  if command -v apt-get >/dev/null 2>&1 && [ -r /etc/os-release ]; then
+    # /etc/os-release is an external system file ShellCheck cannot follow.
+    # shellcheck source=/dev/null
+    . /etc/os-release
+    if [ "${ID:-}" = ubuntu ]; then echo baremetal; return; fi
+  fi
+  echo unsupported
+}
+
+# Echo one of: nvidia | amd | intel | none. Never errors, even with no GPU and
+# no detection tools installed. PCI vendor IDs: 0x10de NVIDIA, 0x1002 AMD/ATI,
+# 0x8086 Intel. A discrete NVIDIA GPU is preferred over an integrated one
+# because it is the device usable for GPU streaming.
+detect_gpu_vendor() {
+  ids=""
+  for f in /sys/class/drm/card*/device/vendor /sys/bus/pci/devices/*/vendor; do
+    [ -r "$f" ] || continue
+    ids="${ids} $(cat "$f" 2>/dev/null || true)"
+  done
+  case " ${ids} " in
+  *0x10de*) echo nvidia; return ;;
+  esac
+  if command -v nvidia-smi >/dev/null 2>&1 || [ -e /dev/nvidia0 ]; then
+    echo nvidia
+    return
+  fi
+  case " ${ids} " in
+  *0x1002*) echo amd; return ;;
+  *0x8086*) echo intel; return ;;
+  esac
+  if command -v lspci >/dev/null 2>&1; then
+    if lspci 2>/dev/null | grep -qiE 'nvidia'; then echo nvidia; return; fi
+    if lspci 2>/dev/null | grep -qiE 'amd|ati|radeon'; then echo amd; return; fi
+    if lspci 2>/dev/null | grep -qiE 'intel'; then echo intel; return; fi
+  fi
+  echo none
+}
+
+# --- install stages (skeletons; bodies added by sibling issues) ---
+
+stage_baseline_desktop() { # XFCE (xubuntu-core) + xrdp -> #29
+  log "baseline desktop (XFCE + xrdp): not yet implemented (#29)"
+  return 0
+}
+
+stage_sunshine() { # Sunshine host + vendor-aware encoder -> #30
+  log "Sunshine host + encoder selection: not yet implemented (#30)"
+  return 0
+}
+
+stage_gpu_display() { # GPU driver + headless virtual display -> #31
+  # Defense-in-depth: never install a Linux GPU driver under WSL2.
+  if is_wsl2; then
+    log "WSL2 detected: refusing GPU driver install (WSLg uses the Windows driver)"
+    return 0
+  fi
+  log "GPU driver + headless virtual display: not yet implemented (#31)"
+  return 0
+}
+
+print_plan() {
+  plan "environment: ${ENVIRONMENT}"
+  plan "gpu vendor:  ${GPU_VENDOR}"
+  case "${ENVIRONMENT}" in
+  baremetal)
+    plan "install XFCE (xubuntu-core) + xrdp; no display manager (boot stays CLI)"
+    plan "install Sunshine; encoder for vendor '${GPU_VENDOR}' (software if none)"
+    if [ "${GPU_VENDOR}" = none ]; then
+      plan "no GPU: skip GPU driver and headless virtual display"
+    else
+      plan "install '${GPU_VENDOR}' GPU driver + headless virtual display"
+    fi
+    ;;
+  wsl2)
+    plan "install XFCE (xubuntu-core) + xrdp"
+    plan "WSL2: rely on WSLg; skip Linux GPU driver and bare-metal Sunshine"
+    ;;
+  unsupported)
+    plan "environment not supported for the desktop layer; nothing to do"
+    ;;
+  esac
+}
+
+ENVIRONMENT="$(detect_environment)"
+GPU_VENDOR="$(detect_gpu_vendor)"
+
+if [ "${DESKTOP_DRY_RUN}" = 1 ]; then
+  print_plan
+  exit 0
+fi
+
+log "environment=${ENVIRONMENT} gpu=${GPU_VENDOR}"
+case "${ENVIRONMENT}" in
+baremetal)
+  stage_baseline_desktop
+  stage_sunshine
+  if [ "${GPU_VENDOR}" = none ]; then
+    log "no GPU detected: skipping GPU driver / virtual display (software encode only)"
+  else
+    stage_gpu_display
+  fi
+  ;;
+wsl2)
+  stage_baseline_desktop
+  log "WSL2: relying on WSLg; skipping Linux GPU driver and bare-metal Sunshine"
+  ;;
+unsupported)
+  log "environment not supported for the desktop layer; nothing to do"
+  ;;
+esac

--- a/lib/desktop.sh
+++ b/lib/desktop.sh
@@ -20,11 +20,14 @@ esac
 log() { printf '[desktop] %s\n' "$*"; }
 plan() { printf '[desktop:plan] %s\n' "$*"; }
 
-# Return success when running under WSL2. Several independent signals are
-# checked so a missing ${WSL_DISTRO_NAME} (custom init, root sessions) cannot
-# misclassify a WSL2 host as bare-metal and trigger a Linux GPU driver install,
-# which would break WSLg (the Windows-side driver exposed through /dev/dxg).
-is_wsl2() {
+# Return success when running under WSL (1 or 2). Several independent signals
+# are checked so a missing ${WSL_DISTRO_NAME} (custom init, root sessions)
+# cannot misclassify a WSL host as bare-metal. WSL1 and WSL2 are deliberately
+# grouped: neither can use a Linux GPU driver (WSL2 exposes the Windows driver
+# through /dev/dxg / WSLg, WSL1 has no GPU passthrough at all), so both must
+# skip the GPU-driver stage. Treating WSL1 as bare-metal would be the unsafe
+# choice, since the bare-metal path may install a GPU driver.
+is_wsl() {
   if [ -n "${WSL_DISTRO_NAME:-}" ]; then return 0; fi
   if [ -e /run/WSL ]; then return 0; fi
   if [ -e /proc/sys/fs/binfmt_misc/WSLInterop ]; then return 0; fi
@@ -35,9 +38,9 @@ is_wsl2() {
   return 1
 }
 
-# Echo one of: wsl2 | baremetal | unsupported.
+# Echo one of: wsl | baremetal | unsupported.
 detect_environment() {
-  if is_wsl2; then echo wsl2; return; fi
+  if is_wsl; then echo wsl; return; fi
   if command -v apt-get >/dev/null 2>&1 && [ -r /etc/os-release ]; then
     # /etc/os-release is an external system file ShellCheck cannot follow.
     # shellcheck source=/dev/null
@@ -92,9 +95,9 @@ stage_sunshine() { # Sunshine host + vendor-aware encoder -> #30
 }
 
 stage_gpu_display() { # GPU driver + headless virtual display -> #31
-  # Defense-in-depth: never install a Linux GPU driver under WSL2.
-  if is_wsl2; then
-    log "WSL2 detected: refusing GPU driver install (WSLg uses the Windows driver)"
+  # Defense-in-depth: never install a Linux GPU driver under WSL (1 or 2).
+  if is_wsl; then
+    log "WSL detected: refusing GPU driver install (no Linux GPU driver under WSL)"
     return 0
   fi
   log "GPU driver + headless virtual display: not yet implemented (#31)"
@@ -114,9 +117,9 @@ print_plan() {
       plan "install '${GPU_VENDOR}' GPU driver + headless virtual display"
     fi
     ;;
-  wsl2)
+  wsl)
     plan "install XFCE (xubuntu-core) + xrdp"
-    plan "WSL2: rely on WSLg; skip Linux GPU driver and bare-metal Sunshine"
+    plan "WSL: rely on WSLg (WSL2); skip Linux GPU driver and bare-metal Sunshine"
     ;;
   unsupported)
     plan "environment not supported for the desktop layer; nothing to do"
@@ -143,9 +146,9 @@ baremetal)
     stage_gpu_display
   fi
   ;;
-wsl2)
+wsl)
   stage_baseline_desktop
-  log "WSL2: relying on WSLg; skipping Linux GPU driver and bare-metal Sunshine"
+  log "WSL: relying on WSLg (WSL2); skipping Linux GPU driver and bare-metal Sunshine"
   ;;
 unsupported)
   log "environment not supported for the desktop layer; nothing to do"

--- a/lib/desktop.sh
+++ b/lib/desktop.sh
@@ -10,7 +10,12 @@ cd "$(cd "$(dirname "$0")"; pwd)/.."
 # stages are filled in by sibling issues (#29 XFCE + xrdp, #30 Sunshine,
 # #31 GPU driver + virtual display). The default CLI setup never calls it.
 
-DESKTOP_DRY_RUN="${DESKTOP_DRY_RUN:-0}"
+# Normalize to 0|1 so a value such as "true" cannot abort a numeric test and so
+# direct invocation behaves the same as going through setup.
+case "${DESKTOP_DRY_RUN:-0}" in
+1 | true | yes | on) DESKTOP_DRY_RUN=1 ;;
+*) DESKTOP_DRY_RUN=0 ;;
+esac
 
 log() { printf '[desktop] %s\n' "$*"; }
 plan() { printf '[desktop:plan] %s\n' "$*"; }
@@ -44,11 +49,13 @@ detect_environment() {
 
 # Echo one of: nvidia | amd | intel | none. Never errors, even with no GPU and
 # no detection tools installed. PCI vendor IDs: 0x10de NVIDIA, 0x1002 AMD/ATI,
-# 0x8086 Intel. A discrete NVIDIA GPU is preferred over an integrated one
-# because it is the device usable for GPU streaming.
+# 0x8086 Intel. Only display devices are inspected (the DRM card nodes, and the
+# VGA/3D/Display lines from lspci) so unrelated PCI devices such as NICs or the
+# chipset cannot be mistaken for a GPU. A discrete NVIDIA GPU is preferred over
+# an integrated one because it is the device usable for GPU streaming.
 detect_gpu_vendor() {
   ids=""
-  for f in /sys/class/drm/card*/device/vendor /sys/bus/pci/devices/*/vendor; do
+  for f in /sys/class/drm/card*/device/vendor; do
     [ -r "$f" ] || continue
     ids="${ids} $(cat "$f" 2>/dev/null || true)"
   done
@@ -64,9 +71,10 @@ detect_gpu_vendor() {
   *0x8086*) echo intel; return ;;
   esac
   if command -v lspci >/dev/null 2>&1; then
-    if lspci 2>/dev/null | grep -qiE 'nvidia'; then echo nvidia; return; fi
-    if lspci 2>/dev/null | grep -qiE 'amd|ati|radeon'; then echo amd; return; fi
-    if lspci 2>/dev/null | grep -qiE 'intel'; then echo intel; return; fi
+    gpus="$(lspci 2>/dev/null | grep -iE 'vga|3d|display' || true)"
+    if printf '%s\n' "${gpus}" | grep -qiE 'nvidia'; then echo nvidia; return; fi
+    if printf '%s\n' "${gpus}" | grep -qiE 'amd|ati|radeon'; then echo amd; return; fi
+    if printf '%s\n' "${gpus}" | grep -qiE 'intel'; then echo intel; return; fi
   fi
   echo none
 }

--- a/setup
+++ b/setup
@@ -71,11 +71,14 @@ then
 fi
 
 # --desktop applies only to a real Ubuntu install. The VM/non-Ubuntu path
-# launches a VM and cannot forward the desktop request, so warn instead of
-# dropping it silently.
+# launches a VM and cannot forward the desktop request, so reject the
+# combination explicitly rather than silently running the base setup. Desktop
+# support inside the VM is a separate concern handled by sibling issues. The
+# non-mutating "--desktop --dry-run" preview already ran above and is exempt.
 if [ "$USE_DESKTOP" -eq 1 ] && [ "$USE_VIRTUAL" -eq 1 ]
 then
-  echo "Warning: --desktop is not forwarded to the VM/non-Ubuntu path; running the base setup only." >&2
+  echo "Error: --desktop is not supported with the VM/non-Ubuntu path; run on a real Ubuntu host, or use --desktop --dry-run to preview the plan." >&2
+  exit 1
 fi
 
 if [ "$USE_VIRTUAL" -eq 1 ]

--- a/setup
+++ b/setup
@@ -23,13 +23,52 @@ then
   fi
 fi
 
-while getopts 'v' opt
+USE_DESKTOP=0
+DESKTOP_DRY_RUN="${DESKTOP_DRY_RUN:-0}"
+
+usage() {
+  echo "Usage: $0 [-v] [--desktop] [--dry-run]" >&2
+}
+
+# POSIX getopts cannot parse long options, so parse arguments manually while
+# keeping the existing -v behavior. Running with no flags is unchanged.
+while [ $# -gt 0 ]
 do
-  case "$opt" in
-    v) USE_VIRTUAL=1 ;;
-    *) echo "Usage: $0 [-v]" >&2; exit 1 ;;
+  case "$1" in
+    -v) USE_VIRTUAL=1 ;;
+    --desktop) USE_DESKTOP=1 ;;
+    --dry-run) DESKTOP_DRY_RUN=1 ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; break ;;
+    *) usage; exit 1 ;;
   esac
+  shift
 done
+
+# Reject stray positional arguments left after a "--" terminator.
+if [ "$#" -gt 0 ]
+then
+  usage
+  exit 1
+fi
+
+# --dry-run is desktop-only; reject it alone so an intended dry run can never
+# fall through to a real install or a VM launch.
+if [ "$DESKTOP_DRY_RUN" -eq 1 ] && [ "$USE_DESKTOP" -eq 0 ]
+then
+  echo "Error: --dry-run requires --desktop" >&2
+  usage
+  exit 1
+fi
+export DESKTOP_DRY_RUN
+
+# The desktop dry run is non-mutating: handle it before any install step and
+# before the VM path so it prints a plan and exits without side effects.
+if [ "$USE_DESKTOP" -eq 1 ] && [ "$DESKTOP_DRY_RUN" -eq 1 ]
+then
+  lib/desktop.sh
+  exit 0
+fi
 
 if [ "$USE_VIRTUAL" -eq 1 ]
 then
@@ -43,5 +82,10 @@ lib/docker.sh
 lib/pwsh.sh
 lib/teardown.sh
 lib/locale.sh
+
+if [ "$USE_DESKTOP" -eq 1 ]
+then
+  lib/desktop.sh
+fi
 
 echo done.

--- a/setup
+++ b/setup
@@ -70,6 +70,14 @@ then
   exit 0
 fi
 
+# --desktop applies only to a real Ubuntu install. The VM/non-Ubuntu path
+# launches a VM and cannot forward the desktop request, so warn instead of
+# dropping it silently.
+if [ "$USE_DESKTOP" -eq 1 ] && [ "$USE_VIRTUAL" -eq 1 ]
+then
+  echo "Warning: --desktop is not forwarded to the VM/non-Ubuntu path; running the base setup only." >&2
+fi
+
 if [ "$USE_VIRTUAL" -eq 1 ]
 then
   lib/virtual.sh

--- a/setup
+++ b/setup
@@ -24,7 +24,13 @@ then
 fi
 
 USE_DESKTOP=0
-DESKTOP_DRY_RUN="${DESKTOP_DRY_RUN:-0}"
+
+# Normalize the dry-run flag/env to 0|1 up front so a value such as "true"
+# from the environment cannot abort the script on a numeric test under set -e.
+case "${DESKTOP_DRY_RUN:-0}" in
+  1 | true | yes | on) DESKTOP_DRY_RUN=1 ;;
+  *) DESKTOP_DRY_RUN=0 ;;
+esac
 
 usage() {
   echo "Usage: $0 [-v] [--desktop] [--dry-run]" >&2
@@ -52,19 +58,13 @@ then
   exit 1
 fi
 
-# --dry-run is desktop-only; reject it alone so an intended dry run can never
-# fall through to a real install or a VM launch.
-if [ "$DESKTOP_DRY_RUN" -eq 1 ] && [ "$USE_DESKTOP" -eq 0 ]
-then
-  echo "Error: --dry-run requires --desktop" >&2
-  usage
-  exit 1
-fi
 export DESKTOP_DRY_RUN
 
-# The desktop dry run is non-mutating: handle it before any install step and
-# before the VM path so it prints a plan and exits without side effects.
-if [ "$USE_DESKTOP" -eq 1 ] && [ "$DESKTOP_DRY_RUN" -eq 1 ]
+# A dry run targets the desktop layer and implies it, so it works via the
+# --dry-run flag or the DESKTOP_DRY_RUN env var on its own. It is non-mutating:
+# handle it before any install step and before the VM path so it prints a plan
+# and exits without side effects.
+if [ "$DESKTOP_DRY_RUN" -eq 1 ]
 then
   lib/desktop.sh
   exit 0


### PR DESCRIPTION
## Summary

Adds the opt-in desktop-layer **foundation** from the roadmap (#27):

- `setup` gains opt-in long flags `--desktop` and `--dry-run` (parsed manually,
  since POSIX `getopts` cannot handle long options) alongside the existing `-v`.
  **Running with no flags is unchanged** — the default CLI install path is
  untouched and never invokes the desktop layer.
- New `lib/desktop.sh` performs **environment detection**
  (`wsl2` / `baremetal` / `unsupported`) and **GPU vendor detection**
  (`nvidia` / `amd` / `intel` / `none`, vendor-neutral — no NVIDIA assumption),
  then prints a **non-mutating dry-run plan**.
- Install work is split into stage skeletons that sibling issues fill in
  (#29 XFCE + xrdp, #30 Sunshine + encoder selection, #31 GPU driver + virtual
  display).
- `.cspell.config.yml`: add `xrdp` to the dictionary.

### Safety properties

- The desktop dry run runs **before** any install step and before the VM path,
  so `--desktop --dry-run` prints a plan and exits 0 **installing nothing** on
  any host (including non-Ubuntu).
- GPU detection **never errors** when no GPU or detection tools are present
  (sysfs PCI vendor IDs first, then `nvidia-smi`/device node, then `lspci`).
- WSL2 is identified through several independent signals, and the GPU-driver
  stage additionally **re-asserts** it is not WSL2 — a Linux GPU driver is never
  installed under WSL2 (it would break WSLg).

## Verification

- `shellcheck setup lib/desktop.sh` — clean
- `pre-push-validate` (markdownlint-cli2 + cspell) — pass
- Live on a WSL2 + NVIDIA host: `./setup --desktop --dry-run` prints the wsl2
  plan and exits 0; `--dry-run` without `--desktop` errors (exit 1); unknown
  flag → usage (exit 1); `-h` → usage (exit 0).
- The `baremetal` and `gpu=none` branches were verified by static review and
  isolated `sh -eu` reproductions (this host cannot exercise them); per the
  issue, real-hardware/Unity verification is an out-of-band manual step.

## Notes

- Stray-argument tolerance is slightly tightened vs the old `getopts`
  (e.g. `./setup -v foo` now errors with usage). The documented `-v` and
  no-flag contracts are unchanged.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added desktop environment and GPU vendor detection for system configuration.
  * Added `--desktop` flag to enable desktop setup workflow.
  * Added `--dry-run` flag to preview installation steps without executing them.

* **Chores**
  * Updated spell checker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->