### PR TITLE
feat: install XFCE and xrdp in the desktop baseline stage

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -38,6 +38,7 @@ words:
   - larstobi
   - lazyjj
   - ludeeus
+  - nodm
   - nyancat
   - ollama
   - pylint
@@ -49,4 +50,6 @@ words:
   - xkbmodel
   - xkboptions
   - xkbvariant
+  - xorgxrdp
   - xrdp
+  - xsession

--- a/lib/desktop.sh
+++ b/lib/desktop.sh
@@ -109,11 +109,13 @@ stage_baseline_desktop() { # XFCE (xubuntu-core) + xrdp
     # Keep the host headless-by-default: force the multi-user (CLI) target and
     # disable any display manager that may already be present. The GUI is
     # reached over xrdp on connect, not via a local login screen.
-    sudo systemctl set-default multi-user.target >/dev/null 2>&1 || true
+    sudo systemctl set-default multi-user.target >/dev/null 2>&1 ||
+      log "warning: could not set multi-user.target; the host may boot to a GUI"
     for dm in lightdm gdm3 sddm lxdm nodm; do
       if systemctl list-unit-files "${dm}.service" >/dev/null 2>&1 &&
         systemctl is-enabled "${dm}.service" >/dev/null 2>&1; then
-        sudo systemctl disable "${dm}.service" >/dev/null 2>&1 || true
+        sudo systemctl disable "${dm}.service" >/dev/null 2>&1 ||
+          log "warning: could not disable ${dm}; it may still show a login screen"
       fi
     done
     # Enable and start xrdp; surface a real failure instead of hiding it.

--- a/lib/desktop.sh
+++ b/lib/desktop.sh
@@ -114,13 +114,19 @@ stage_baseline_desktop() { # XFCE (xubuntu-core) + xrdp
     for dm in lightdm gdm3 sddm lxdm nodm; do
       if systemctl list-unit-files "${dm}.service" >/dev/null 2>&1 &&
         systemctl is-enabled "${dm}.service" >/dev/null 2>&1; then
-        sudo systemctl disable "${dm}.service" >/dev/null 2>&1 ||
+        # --now also stops a currently-running login screen, not just the next
+        # boot, so the host is headless immediately.
+        sudo systemctl disable --now "${dm}.service" >/dev/null 2>&1 ||
           log "warning: could not disable ${dm}; it may still show a login screen"
       fi
     done
-    # Enable and start xrdp; surface a real failure instead of hiding it.
-    sudo systemctl enable --now xrdp ||
-      log "warning: could not enable/start xrdp; start it manually"
+    # xrdp is the access path for the desktop layer; if it cannot be enabled on a
+    # systemd host the desktop is unreachable, so fail loudly rather than leaving
+    # a broken install behind.
+    sudo systemctl enable --now xrdp || {
+      log "error: failed to enable xrdp (required for the desktop layer)"
+      exit 1
+    }
     log "default systemd target: $(systemctl get-default 2>/dev/null || echo unknown)"
   else
     log "systemd not detected (e.g. WSL without systemd): start xrdp manually"

--- a/lib/desktop.sh
+++ b/lib/desktop.sh
@@ -93,9 +93,47 @@ detect_gpu_vendor() {
 
 # --- install stages (skeletons; bodies added by sibling issues) ---
 
-stage_baseline_desktop() { # XFCE (xubuntu-core) + xrdp -> #29
-  log "baseline desktop (XFCE + xrdp): not yet implemented (#29)"
-  return 0
+stage_baseline_desktop() { # XFCE (xubuntu-core) + xrdp
+  log "installing XFCE (xubuntu-core) + xrdp + xorgxrdp"
+  # Refresh the index defensively so a standalone or WSL invocation does not
+  # abort the install on a stale cache.
+  sudo apt-get update
+  # --no-install-recommends keeps the display manager (a recommend of
+  # xubuntu-core) out, so the host stays headless by default.
+  sudo apt-get install -y --no-install-recommends \
+    xubuntu-core xrdp xorgxrdp
+
+  # systemd actions only apply where systemd is the init system (bare-metal,
+  # and WSL only when systemd is enabled in wsl.conf). Detect it once.
+  if [ -d /run/systemd/system ]; then
+    # Keep the host headless-by-default: force the multi-user (CLI) target and
+    # disable any display manager that may already be present. The GUI is
+    # reached over xrdp on connect, not via a local login screen.
+    sudo systemctl set-default multi-user.target >/dev/null 2>&1 || true
+    for dm in lightdm gdm3 sddm lxdm nodm; do
+      if systemctl list-unit-files "${dm}.service" >/dev/null 2>&1 &&
+        systemctl is-enabled "${dm}.service" >/dev/null 2>&1; then
+        sudo systemctl disable "${dm}.service" >/dev/null 2>&1 || true
+      fi
+    done
+    # Enable and start xrdp; surface a real failure instead of hiding it.
+    sudo systemctl enable --now xrdp ||
+      log "warning: could not enable/start xrdp; start it manually"
+    log "default systemd target: $(systemctl get-default 2>/dev/null || echo unknown)"
+  else
+    log "systemd not detected (e.g. WSL without systemd): start xrdp manually"
+  fi
+
+  # xrdp honors a user-provided ~/.xsession (managed by dotfiles) when present;
+  # otherwise it falls back to the system x-session-manager set here, so a
+  # connection lands in XFCE out of the box. The alternative may be absent on a
+  # minimal image, so a failure here is non-fatal.
+  xfce_session="$(command -v xfce4-session || true)"
+  if [ -n "${xfce_session}" ] &&
+    command -v update-alternatives >/dev/null 2>&1; then
+    sudo update-alternatives --set x-session-manager "${xfce_session}" ||
+      log "warning: could not set XFCE as the default x-session-manager"
+  fi
 }
 
 stage_sunshine() { # Sunshine host + vendor-aware encoder -> #30


### PR DESCRIPTION
## Summary

Implements the baseline desktop install stage from roadmap #27. Fills in
`stage_baseline_desktop` in `lib/desktop.sh`:

- installs `xubuntu-core` + `xrdp` + `xorgxrdp` via the `--desktop` path only;
  the default CLI install (`cloud-init.yml`) is unchanged
- `--no-install-recommends` omits the display manager (a *recommend* of
  `xubuntu-core`); on systemd hosts the script forces `multi-user.target` and
  disables any present DM, so the host stays headless and the GUI is reached
  over xrdp on connect
- enables+starts `xrdp` and sets XFCE as the default `x-session-manager`, while
  a user-provided `~/.xsession` (managed by dotfiles) still takes precedence
- detects WSL-without-systemd and skips the systemd steps with a clear note

Advisory-review hardening already folded in: defensive `apt-get update`, systemd
detection (no silent no-op on WSL), broadened DM list, `command -v`-resolved
XFCE session path, and surfaced (logged) failures instead of blanket `|| true`.

## Verification

- `shellcheck setup lib/desktop.sh` — clean
- cspell + markdownlint — pass (added `nodm`, `xorgxrdp`, `xsession`)
- `./setup --desktop --dry-run` still exits 0 (stage bodies run only in real mode)
- The install itself is system-mutating and is verified by static review + the
  dry-run plan, not by executing it on this host (per the issue's intent).

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented desktop environment installation with graphical desktop and remote desktop access support, including system service configuration and session management.

* **Chores**
  * Updated spell check configuration with additional recognized terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->