### PR TITLE
feat: enable the GPU driver and a headless virtual display

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -37,6 +37,7 @@ words:
   - kuroné
   - larstobi
   - lazyjj
+  - libgl
   - ludeeus
   - nodm
   - nvenc

--- a/lib/desktop.sh
+++ b/lib/desktop.sh
@@ -251,22 +251,23 @@ stage_gpu_display() { # GPU driver + headless virtual display
     log "installing the NVIDIA driver and enabling a headless virtual display"
     sudo apt-get install -y --no-install-recommends ubuntu-drivers-common ||
       { log "warning: could not install ubuntu-drivers-common; skipping NVIDIA driver"; return 0; }
-    if command -v ubuntu-drivers >/dev/null 2>&1; then
-      sudo ubuntu-drivers autoinstall ||
-        log "warning: ubuntu-drivers could not auto-install an NVIDIA driver"
-    else
-      log "warning: ubuntu-drivers not found; install the NVIDIA driver manually"
-    fi
-    # AllowEmptyInitialConfiguration coexists with the real driver and lets the
-    # GPU X server start with no monitor attached, so it is safe even when a
-    # monitor is present.
-    sudo tee /etc/X11/xorg.conf.d/10-nvidia-headless.conf >/dev/null <<'EOF'
+    # Only write the nvidia headless xorg drop-in once the driver is actually
+    # installed: a config that forces Driver "nvidia" with no driver present
+    # would make Xorg fail to start.
+    if command -v ubuntu-drivers >/dev/null 2>&1 && sudo ubuntu-drivers autoinstall; then
+      # AllowEmptyInitialConfiguration coexists with the real driver and lets the
+      # GPU X server start with no monitor attached, so it is safe even when a
+      # monitor is present.
+      sudo tee /etc/X11/xorg.conf.d/10-nvidia-headless.conf >/dev/null <<'EOF'
 Section "Device"
     Identifier "nvidia-headless"
     Driver "nvidia"
     Option "AllowEmptyInitialConfiguration" "true"
 EndSection
 EOF
+    else
+      log "warning: NVIDIA driver not installed (ubuntu-drivers missing or failed); skipping the nvidia headless xorg config"
+    fi
     ;;
   amd | intel)
     log "ensuring the ${GPU_VENDOR} userspace stack (the kernel driver is built in)"

--- a/lib/desktop.sh
+++ b/lib/desktop.sh
@@ -23,6 +23,13 @@ case "${DESKTOP_SUNSHINE_WSL:-0}" in
 *) DESKTOP_SUNSHINE_WSL=0 ;;
 esac
 
+# Opt-in: configure a dummy headless virtual display for AMD/Intel. It can
+# override a connected monitor, so it is only for genuinely monitor-less hosts.
+case "${DESKTOP_DUMMY_DISPLAY:-0}" in
+1 | true | yes | on) DESKTOP_DUMMY_DISPLAY=1 ;;
+*) DESKTOP_DUMMY_DISPLAY=0 ;;
+esac
+
 log() { printf '[desktop] %s\n' "$*"; }
 plan() { printf '[desktop:plan] %s\n' "$*"; }
 
@@ -228,14 +235,81 @@ stage_sunshine() { # Sunshine host + vendor-aware encoder
   log "Sunshine user config (~/.config/sunshine) is delegated to dotfiles"
 }
 
-stage_gpu_display() { # GPU driver + headless virtual display -> #31
+stage_gpu_display() { # GPU driver + headless virtual display
   # Defense-in-depth: never install a Linux GPU driver under WSL (1 or 2).
   if is_wsl; then
     log "WSL detected: refusing GPU driver install (no Linux GPU driver under WSL)"
     return 0
   fi
-  log "GPU driver + headless virtual display: not yet implemented (#31)"
-  return 0
+  # This stage is the least critical part of the desktop layer (a streaming
+  # nicety), and the xrdp desktop already works, so a package failure degrades
+  # gracefully instead of aborting the whole setup.
+  sudo install -d /etc/X11/xorg.conf.d ||
+    { log "warning: could not create /etc/X11/xorg.conf.d; skipping GPU display setup"; return 0; }
+  case "${GPU_VENDOR}" in
+  nvidia)
+    log "installing the NVIDIA driver and enabling a headless virtual display"
+    sudo apt-get install -y --no-install-recommends ubuntu-drivers-common ||
+      { log "warning: could not install ubuntu-drivers-common; skipping NVIDIA driver"; return 0; }
+    if command -v ubuntu-drivers >/dev/null 2>&1; then
+      sudo ubuntu-drivers autoinstall ||
+        log "warning: ubuntu-drivers could not auto-install an NVIDIA driver"
+    else
+      log "warning: ubuntu-drivers not found; install the NVIDIA driver manually"
+    fi
+    # AllowEmptyInitialConfiguration coexists with the real driver and lets the
+    # GPU X server start with no monitor attached, so it is safe even when a
+    # monitor is present.
+    sudo tee /etc/X11/xorg.conf.d/10-nvidia-headless.conf >/dev/null <<'EOF'
+Section "Device"
+    Identifier "nvidia-headless"
+    Driver "nvidia"
+    Option "AllowEmptyInitialConfiguration" "true"
+EndSection
+EOF
+    ;;
+  amd | intel)
+    log "ensuring the ${GPU_VENDOR} userspace stack (the kernel driver is built in)"
+    sudo apt-get install -y --no-install-recommends mesa-utils libgl1-mesa-dri ||
+      log "warning: could not install the ${GPU_VENDOR} mesa userspace"
+    # The dummy driver can override a connected monitor, so the headless display
+    # is opt-in (DESKTOP_DUMMY_DISPLAY=1) and intended for monitor-less hosts.
+    if [ "${DESKTOP_DUMMY_DISPLAY}" = 1 ]; then
+      sudo apt-get install -y --no-install-recommends xserver-xorg-video-dummy ||
+        { log "warning: could not install xserver-xorg-video-dummy; skipping dummy display"; return 0; }
+      sudo tee /etc/X11/xorg.conf.d/10-headless-dummy.conf >/dev/null <<'EOF'
+Section "Device"
+    Identifier "headless-dummy"
+    Driver "dummy"
+    VideoRam 256000
+EndSection
+Section "Monitor"
+    Identifier "headless-monitor"
+    HorizSync 5.0 - 1000.0
+    VertRefresh 5.0 - 200.0
+EndSection
+Section "Screen"
+    Identifier "headless-screen"
+    Device "headless-dummy"
+    Monitor "headless-monitor"
+    DefaultDepth 24
+    SubSection "Display"
+        Depth 24
+        Modes "1920x1080"
+    EndSubSection
+EndSection
+EOF
+      log "dummy headless display configured (overrides any local monitor)"
+    else
+      log "${GPU_VENDOR}: skipping the dummy headless display (set DESKTOP_DUMMY_DISPLAY=1 on a monitor-less host)"
+    fi
+    ;;
+  *)
+    log "no GPU vendor detected; skipping GPU driver / virtual display"
+    return 0
+    ;;
+  esac
+  log "GPU display stage complete"
 }
 
 print_plan() {
@@ -245,11 +319,17 @@ print_plan() {
   baremetal)
     plan "install XFCE (xubuntu-core) + xrdp; no display manager (boot stays CLI)"
     plan "install Sunshine (encoder: $(select_encoder))"
-    if [ "${GPU_VENDOR}" = none ]; then
-      plan "no GPU: skip GPU driver and headless virtual display"
-    else
-      plan "install '${GPU_VENDOR}' GPU driver + headless virtual display"
-    fi
+    case "${GPU_VENDOR}" in
+    nvidia) plan "install NVIDIA driver (ubuntu-drivers) + AllowEmptyInitialConfiguration headless display" ;;
+    amd | intel)
+      if [ "${DESKTOP_DUMMY_DISPLAY}" = 1 ]; then
+        plan "install ${GPU_VENDOR} mesa userspace + dummy headless display (overrides a local monitor)"
+      else
+        plan "install ${GPU_VENDOR} mesa userspace (set DESKTOP_DUMMY_DISPLAY=1 for a dummy headless display)"
+      fi
+      ;;
+    *) plan "no GPU: skip GPU driver and headless virtual display" ;;
+    esac
     ;;
   wsl)
     plan "install XFCE (xubuntu-core) + xrdp"


### PR DESCRIPTION
## Summary

Implements the GPU driver + headless virtual display stage from roadmap #27
(`stage_gpu_display`), reached only on baremetal, non-WSL, with a GPU present:

- **NVIDIA**: install the driver via `ubuntu-drivers autoinstall` and write an
  `AllowEmptyInitialConfiguration` xorg drop-in so the GPU X server starts with
  no monitor attached (coexists safely with a real monitor).
- **AMD/Intel**: install the mesa userspace (the amdgpu/i915 kernel driver is
  built in). The dummy headless display is **opt-in** via `DESKTOP_DUMMY_DISPLAY=1`
  because the dummy driver can override a connected monitor — it is intended for
  genuinely monitor-less hosts only.
- **WSL** is hard-guarded (never installs a Linux GPU driver). Package failures
  degrade gracefully (warn + skip) since this is the least critical part of the
  desktop layer and the xrdp desktop already works.
- The dry-run plan lists the per-vendor driver + virtual-display actions.
- Touches neither the systemd default target nor any display manager (owned by
  the baseline stage).

Advisory-review hardening folded in up front: `ubuntu-drivers autoinstall` (not
`install`), guarded apt installs, the `DESKTOP_DUMMY_DISPLAY` opt-in for the
risky dummy path, and per-vendor dry-run plan lines.

## Verification

- `shellcheck setup lib/desktop.sh` — clean
- cspell + markdownlint — pass (added `libgl`)
- `./setup --desktop --dry-run` exits 0 and shows the GPU plan lines
- The install is system-mutating and verified by static review + the dry-run
  plan, not by executing it on this host (per the issue's intent).

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)
