### PR TITLE
feat: switch the IDD helper runtime to ephemeral-npx

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -20,7 +20,23 @@
     "post-fix-validate": "npx -y markdownlint-cli2 --fix \"**/*.md\" && npx -y markdownlint-cli2 \"**/*.md\" && npx -y cspell lint \"**\" --no-progress"
   },
   "helperRuntime": {
-    "profile": "instructions-only"
+    "profile": "ephemeral-npx"
+  },
+  "advisoryBotLogins": [
+    "copilot-pull-request-reviewer[bot]",
+    "coderabbitai[bot]",
+    "chatgpt-codex-connector[bot]"
+  ],
+  "advisoryWait": {
+    "convergenceScope": "idd-claimed"
+  },
+  "worktreeGuard": {
+    "enabled": true
+  },
+  "labels": {
+    "roadmapLabelName": "roadmap",
+    "blockedByHumanLabelName": "status:blocked-by-human",
+    "needsDecisionLabelName": "status:needs-decision"
   },
   "issueScope": "roadmap-first",
   "orphanFirstPolicy": "none",

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -65,7 +65,9 @@ scripts.
   [Helper runtime](#helper-runtime-ephemeral-npx) below)
 - Advisory bot logins: `copilot-pull-request-reviewer[bot]`,
   `coderabbitai[bot]`, `chatgpt-codex-connector[bot]`
-- Advisory-wait convergence scope: `idd-claimed` (see rationale below)
+- Advisory-wait convergence scope: `idd-claimed` (see
+  [Helper runtime](#helper-runtime-ephemeral-npx) below for the
+  rationale)
 - Worktree guard: `enabled: true` (see
   [Helper runtime](#helper-runtime-ephemeral-npx) below for the
   activation step)
@@ -107,17 +109,17 @@ on every upstream bump. `ephemeral-npx` avoids both costs.
 
   `core.hooksPath` is uncommitted git config, not repository content,
   so every fresh clone or ephemeral agent environment must rerun this
-  step. Because this repository does not enable
-  `extensions.worktreeConfig`, the setting is shared across every
-  worktree of a given clone rather than scoped to one — this is the
-  correct scope for this guard: `.githooks/_idd-worktree-guard.sh`
-  only ever blocks a commit or push made from the *primary* worktree
-  while `HEAD` sits on an `issue/*` or `roadmap-audit/*` branch, so it
-  is a guaranteed no-op in every sibling implementation worktree.
+  step. This plain (non-`--worktree`-scoped) form writes to the
+  repository's shared config, so it applies across every worktree of a
+  given clone rather than to just one — this is the correct scope for
+  this guard: `.githooks/_idd-worktree-guard.sh` only ever blocks a
+  commit or push made from the *primary* worktree while `HEAD` sits on
+  an `issue/*` or `roadmap-audit/*` branch, so it is a guaranteed no-op
+  in every sibling implementation worktree.
 - Why `advisoryWait.convergenceScope` is `idd-claimed` rather than the
-  `all-prs` default: this repository auto-merges Dependabot pull
-  requests, which carry no IDD claim and would otherwise be swept into
-  an advisory-convergence gate they can never satisfy on their own.
+  `all-prs` default: this repository merges Dependabot pull requests,
+  which carry no IDD claim and would otherwise be swept into an
+  advisory-convergence gate they can never satisfy on their own.
 - `advisoryWait.primaryBotLogin` and `advisoryWait.secondaryBotLogin`
   are deliberately left unset: Copilot is tracked without a pinned
   login, and CodeRabbit reviews through an app install rather than as

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -61,7 +61,16 @@ scripts.
   source layout by #44; a future template resync must copy the
   upstream bundle to that same installed path, not the pre-#44
   location)
-- Helper runtime profile: `instructions-only`
+- Helper runtime profile: `ephemeral-npx` (see
+  [Helper runtime](#helper-runtime-ephemeral-npx) below)
+- Advisory bot logins: `copilot-pull-request-reviewer[bot]`,
+  `coderabbitai[bot]`, `chatgpt-codex-connector[bot]`
+- Advisory-wait convergence scope: `idd-claimed` (see rationale below)
+- Worktree guard: `enabled: true` (see
+  [Helper runtime](#helper-runtime-ephemeral-npx) below for the
+  activation step)
+- Labels: roadmap `roadmap`, blocked-by-human
+  `status:blocked-by-human`, needs-decision `status:needs-decision`
 - Claim timing: stale `PT24H` / heartbeat `PT12H` (defaults)
 
 This is a personal repository with a single owner and maintainer
@@ -70,3 +79,47 @@ self-authorizes before starting work. Pull-request review automation in
 this repository is handled by CodeRabbit
 ([`.coderabbit.yaml`](../.coderabbit.yaml)); the `copilot-advisory` profile
 treats such bot reviews as advisory rather than blocking.
+
+## Helper runtime (`ephemeral-npx`)
+
+This repository has no `package.json` and no lockfile, ruling out the
+`package-manager` profile, which requires a manifest to resolve against.
+`vendored-node` was declined too, though it needs no manifest: it copies
+a local helper bundle into the repository at import time, which would
+add files to this shell-and-Terraform repository and need re-vendoring
+on every upstream bump. `ephemeral-npx` avoids both costs.
+
+- Pinned helper package spec:
+  `https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d`
+  — intentionally pinned to the same commit the instruction files were
+  imported from in #41, so a helper's JSON output contract can never
+  drift away from the instruction step that reads it.
+- Canonical invocation form: `npx --yes --package <pinned-spec>
+  idd-<helper>`. Under this profile the `idd-*` bin facade is the
+  authoritative surface, not `node scripts/*.mjs`.
+- A helper failure is a stop-and-ask condition, never a silent
+  fallback to prose.
+- One-time activation for the worktree guard:
+
+  ```sh
+  git config core.hooksPath .githooks && chmod +x .githooks/pre-commit .githooks/pre-push
+  ```
+
+  `core.hooksPath` is uncommitted git config, not repository content,
+  so every fresh clone or ephemeral agent environment must rerun this
+  step. Because this repository does not enable
+  `extensions.worktreeConfig`, the setting is shared across every
+  worktree of a given clone rather than scoped to one — this is the
+  correct scope for this guard: `.githooks/_idd-worktree-guard.sh`
+  only ever blocks a commit or push made from the *primary* worktree
+  while `HEAD` sits on an `issue/*` or `roadmap-audit/*` branch, so it
+  is a guaranteed no-op in every sibling implementation worktree.
+- Why `advisoryWait.convergenceScope` is `idd-claimed` rather than the
+  `all-prs` default: this repository auto-merges Dependabot pull
+  requests, which carry no IDD claim and would otherwise be swept into
+  an advisory-convergence gate they can never satisfy on their own.
+- `advisoryWait.primaryBotLogin` and `advisoryWait.secondaryBotLogin`
+  are deliberately left unset: Copilot is tracked without a pinned
+  login, and CodeRabbit reviews through an app install rather than as
+  a requestable reviewer, so it cannot satisfy the once-per-HEAD
+  secondary-bot contract.


### PR DESCRIPTION
## Summary

Opts this repository into the wider `iddVersion 0.4.0` policy surface
that #41 imported but did not yet activate:

- `helperRuntime.profile`: `instructions-only` -> `ephemeral-npx`. This
  repository has no `package.json`/lockfile (rules out `package-manager`)
  and `vendored-node` would add files and need re-vendoring on every
  upstream bump, so `ephemeral-npx` is the evidence-backed choice — it
  already works here (`fix-validate`/`pre-push-validate` already run
  `npx -y ...`).
- `advisoryBotLogins`: the three bots that actually review PRs here
  (`copilot-pull-request-reviewer[bot]`, `coderabbitai[bot]`,
  `chatgpt-codex-connector[bot]`), so ack-only courtesy comments stop
  resetting review currency.
- `advisoryWait.convergenceScope`: `idd-claimed` rather than the
  `all-prs` default, since this repository auto-merges Dependabot PRs
  that carry no IDD claim and would otherwise be swept into a
  convergence gate they can never satisfy.
- `worktreeGuard.enabled`: `true`, activating the `.githooks/` guard
  imported in `d81554b` (previously inert with no config opt-in).
- `labels.*`: records the `roadmap` / `status:blocked-by-human` /
  `status:needs-decision` names this repository actually uses, so they
  no longer fall through to unwritten upstream defaults.

`docs/idd-policy.md` mirrors all six values and adds a new "Helper
runtime (`ephemeral-npx`)" section recording the pinned helper package
spec, the canonical `npx --yes --package <pinned-spec> idd-<helper>`
invocation form, the helper-failure stop-and-ask rule, and the one-time
`git config core.hooksPath .githooks` activation step.

## Notes

- **`chatgpt-codex-connector[bot]` is unverified against observed
  activity in this repository** — only the other two logins have
  actually shown up reviewing PRs here (#62, #66). The issue is
  owner-authored, so it's taken at face value, but flagging it since it
  differs from the other two, which are directly confirmed.
- **`core.hooksPath` is local, uncommitted git config, not something
  this diff can show as landed.** I ran the documented activation step
  in this environment to verify AC #5 (`idd-doctor` reporting no
  enabled-but-inert worktree-guard warning) — confirmed clean. Because
  this repository does not enable `extensions.worktreeConfig`, that
  setting is shared across every worktree of a given local clone rather
  than scoped to one; this is the *correct* scope for this specific
  guard (`.githooks/_idd-worktree-guard.sh` only ever blocks a commit
  made from the *primary* worktree while `HEAD` sits on an `issue/*` or
  `roadmap-audit/*` branch, so it is a guaranteed no-op for every
  sibling worktree, including any other session's concurrent worktree
  under the same clone). Every other clone/environment must still run
  this step itself per the doc.
- Validated: `npx --yes --package <pinned-spec> idd-doctor` reports no
  config-to-prose drift and no inert-worktree-guard warning (this also
  covers AC #1's schema-validation requirement, since the doctor's own
  drift check re-validates `config.json` against `policy.schema.json`).
  `markdownlint-cli2` and `cspell` both pass.

Closes #42


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the IDD policy to document the ephemeral helper runtime, pinned package usage, invocation requirements, failure handling, and worktree safeguards.
  - Added guidance for advisory bot access, convergence scope, roadmap labels, human-blocked status, and decision-needed status.

- **Configuration**
  - Updated IDD settings to enable the new helper runtime, worktree guarding, advisory access controls, and status-label configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->