### PR TITLE
feat: add the Claude Code permission baseline with merge authority

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,53 @@
+{
+  "$comment": "Claude Code permission baseline for this repository, adapted from the opt-in idd-template/.claude/settings.json baseline. This repository records mergePolicy: fully_autonomous_merge in .github/idd/config.json and docs/idd-policy.md and is a single-owner personal repository, so unlike the opt-in template counterpart this copy allows `gh pr merge` and does not deny the idd-merge-execute helper -- see docs/permissions.md#claude-code-permission-baseline and docs/idd-policy.md for the recorded rationale. `gh api` is deliberately NOT allowlisted here at all -- see the gh-api DELETE-verb trap in docs/permissions.md before adding any `gh api` entry yourself. Personal additions belong in .claude/settings.local.json, which layers on top of this file.",
+  "permissions": {
+    "allow": [
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git show*)",
+      "Bash(git branch --list*)",
+      "Bash(git branch --show-current)",
+      "Bash(git branch -a*)",
+      "Bash(git branch -v*)",
+      "Bash(git worktree list*)",
+      "Bash(git rev-parse*)",
+      "Bash(git fetch origin*)",
+      "Bash(git remote -v)",
+      "Bash(git remote show*)",
+      "Bash(git blame*)",
+      "Bash(gh issue view*)",
+      "Bash(gh issue list*)",
+      "Bash(gh issue comment*)",
+      "Bash(gh issue edit*)",
+      "Bash(gh pr view*)",
+      "Bash(gh pr list*)",
+      "Bash(gh pr diff*)",
+      "Bash(gh pr checks*)",
+      "Bash(gh pr create*)",
+      "Bash(gh pr comment*)",
+      "Bash(gh pr edit*)",
+      "Bash(gh pr review*)",
+      "Bash(gh pr merge*)",
+      "Bash(gh label list*)",
+      "Bash(gh label create*)",
+      "Bash(gh search*)",
+      "Bash(gh repo view*)",
+      "Bash(gh auth status)",
+      "Bash(npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d idd-*)"
+    ],
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(git push --force-with-lease*)",
+      "Bash(git push -f*)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -f*)",
+      "Bash(git branch -D*)",
+      "Bash(gh repo delete*)",
+      "Bash(gh issue delete*)",
+      "Bash(gh api -X DELETE*)",
+      "Bash(gh api --method DELETE*)",
+      "Bash(gh api --method=DELETE*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,11 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/archives,homebrew,linux,macos,terraform,vim,visualstudiocode,windows
+
+### Claude Code ###
+# Personal permission overrides layered on top of .claude/settings.json
+.claude/settings.local.json
+# Some machine-level git configs treat .claude/* as local-only by
+# default; force-track the shared repository baseline explicitly so a
+# blanket `git add` on such a machine cannot silently drop it.
+!.claude/settings.json

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -74,6 +74,17 @@ scripts.
 - Labels: roadmap `roadmap`, blocked-by-human
   `status:blocked-by-human`, needs-decision `status:needs-decision`
 - Claim timing: stale `PT24H` / heartbeat `PT12H` (defaults)
+- Claude Code permission baseline: installed at `.claude/settings.json`
+  (#43), adapted from the opt-in template baseline documented in
+  [`docs/permissions.md`](permissions.md#claude-code-permission-baseline).
+  Two deltas from that opt-in default, both following from the
+  `fully_autonomous_merge` policy already recorded above: `gh pr merge`
+  is allowlisted, and the `idd-merge-execute` deny entries are dropped
+  so `--apply` merges are not blocked; the generic `node scripts/*` /
+  `node bin/*` allow entries are replaced with this repository's actual
+  `ephemeral-npx` invocation form. Every other allow/deny entry,
+  including the deliberate absence of any `gh api` allow, matches
+  upstream unchanged.
 
 This is a personal repository with a single owner and maintainer
 (`kurone-kito`). The issue-author approval gate stays enabled; the owner

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -77,14 +77,14 @@ scripts.
 - Claude Code permission baseline: installed at `.claude/settings.json`
   (#43), adapted from the opt-in template baseline documented in
   [`docs/permissions.md`](permissions.md#claude-code-permission-baseline).
-  Two deltas from that opt-in default, both following from the
+  Three deltas from that opt-in default. Two follow directly from the
   `fully_autonomous_merge` policy already recorded above: `gh pr merge`
   is allowlisted, and the `idd-merge-execute` deny entries are dropped
-  so `--apply` merges are not blocked; the generic `node scripts/*` /
-  `node bin/*` allow entries are replaced with this repository's actual
-  `ephemeral-npx` invocation form. Every other allow/deny entry,
-  including the deliberate absence of any `gh api` allow, matches
-  upstream unchanged.
+  so `--apply` merges are not blocked. The third is unrelated to merge
+  policy: the generic `node scripts/*` / `node bin/*` allow entries are
+  replaced with this repository's actual `ephemeral-npx` invocation
+  form. Every other allow/deny entry, including the deliberate absence
+  of any `gh api` allow, matches upstream unchanged.
 
 This is a personal repository with a single owner and maintainer
 (`kurone-kito`). The issue-author approval gate stays enabled; the owner


### PR DESCRIPTION
## Summary

Adds `.claude/settings.json`, adapted from the upstream opt-in
permission baseline (`idd-template/.claude/settings.json`), with
exactly the two deltas the issue authorizes:

- allowlist `Bash(gh pr merge*)`
- drop the `idd-merge-execute` deny entries

Both follow from `mergePolicy: fully_autonomous_merge`, already
recorded in this repository's `.github/idd/config.json` and
`docs/idd-policy.md`. Also replaces the generic
`Bash(node scripts/*)` / `Bash(node bin/*)` allow entries with the
`ephemeral-npx` invocation form this repository actually uses (per
#42), and adds `.claude/settings.local.json` to `.gitignore`. Every
other allow/deny entry, including the deliberate absence of any
`gh api` allow, matches upstream byte-for-byte — confirmed with a
programmatic array diff against the cached upstream file.

`docs/idd-policy.md` records both deltas and cross-references the
existing `docs/permissions.md` explanation (already resynced by #41)
rather than re-explaining the reasoning, to avoid the two files
drifting apart on a future edit.

## A machine-config trap this PR also closes

Self-review caught that `.claude/settings.json` was silently matched
by this build environment's *global* git excludes file (a personal,
machine-level `.claude/* ` pattern that treats everything directly
under `.claude/` as local-only by default, negated only for
`skills/`/`agents/`/`commands/`). `git add -A` exited 0 while quietly
dropping the new file — no error, no warning. Added
`!.claude/settings.json` to this repository's own `.gitignore` so a
blanket `git add` can't silently ship a PR missing its own core
deliverable, here or on any other machine with a similar global
default. Verified with `git check-ignore` before and after.

## Notes

- **`gh api` surface (question, not a unilateral delta)**: every IDD
  marker this session posts (claim markers, watermarks, baselines,
  `advisory-wait:`, disposition replies) goes through `gh api -f
  body=...` or GraphQL (`minimizeComment`, `resolveReviewThread`)
  because `gh issue comment` silently rejects HTML-comment-only
  bodies. None of that is allowlisted by this baseline as specified,
  so an unattended session still prompts on every one of those calls.
  Not added here — the issue says to keep everything else as upstream
  ships it, and upstream's own `docs/permissions.md` documents why a
  `gh api` allow can't be narrowed safely against the DELETE-verb
  trap — but flagging it in case a narrow, single-purpose exact-match
  entry (e.g. `Bash(gh api repos/kurone-kito/setup.ubuntu/issues/*/comments*)`)
  is worth a follow-up.
- **Stale premise**: the issue's Background says "this repository has
  no `.claude/` directory at all" — true when #43 was authored, no
  longer true since #44 created `.claude/skills/issue-authoring/`. The
  deliverable is unaffected either way.
- **Doc-accuracy aside (out of scope here)**: `docs/permissions.md`
  (upstream-owned, resynced by #41) claims Claude Code's Bash
  permission matching only supports a *trailing* wildcard. Claude
  Code's own docs show wildcards are supported at any position,
  including mid-string. Not fixed here since `docs/permissions.md`
  isn't a candidate file for #43 and is template-owned content that
  would drift on the next resync — flagging in case it's worth a small
  upstream/local follow-up later.

Closes #43


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the standard Claude Code permission baseline, including installation details and policy deviations.

* **Chores**
  * Added shared development permission settings for approved read, GitHub, authentication, and merge operations.
  * Added safeguards against destructive repository actions.
  * Updated ignore rules to preserve shared settings while excluding local overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->