### PR TITLE
ci: add the idd-doctor health gate

### DIFF
--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -1,0 +1,25 @@
+name: IDD doctor
+
+on: pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  idd-doctor:
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+      - name: Run idd-doctor
+        run: >-
+          npx --yes --package
+          https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d
+          idd-doctor

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -156,3 +156,16 @@ on every upstream bump. `ephemeral-npx` avoids both costs.
   login, and CodeRabbit reviews through an app install rather than as
   a requestable reviewer, so it cannot satisfy the once-per-HEAD
   secondary-bot contract.
+- CI-side consumer: `.github/workflows/idd-doctor.yml` (#46) resolves
+  its `idd-doctor` invocation from the pinned spec above. The same
+  commit SHA now has to stay in sync across four locations on a future
+  resync: the two occurrences in this file (the
+  [imported-snapshot line](#imported-template-snapshot) and the pinned
+  spec above), `.claude/settings.json`'s permission allow-list (#43),
+  and this workflow file. The workflow omits `--strict`: strict mode's
+  sibling-worktree check has no observable signal in a CI checkout —
+  `pull_request` runs always check out a detached commit, never a
+  named `issue/*`/`roadmap-audit/*` branch, so the violation `--strict`
+  guards against structurally cannot occur there. Enforcement for that
+  rule stays local, via `.githooks/pre-commit`/`pre-push` and a
+  developer's own `idd-doctor --strict` run.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/idd-doctor.yml`, following `lint.yml`'s
conventions: same `actions/checkout` pin, `concurrency` group, and
`permissions: contents: read`. Diverges only where the issue directs —
`on: pull_request` only (no `push`), an explicit `ref: ${{ github.sha }}`
on checkout, and a `timeout-minutes: 5` job budget for the npx network
fetch. Runs `idd-doctor` via this repository's pinned `ephemeral-npx`
spec, without `--strict`: strict mode's sibling-worktree check has no
observable signal in a detached-HEAD CI checkout, so that enforcement
stays with the local `.githooks/pre-commit`/`pre-push` hooks and a
developer's own `idd-doctor --strict` run.

Records the new gate in `docs/idd-policy.md`, next to the
helper-runtime decision, including the `--strict` rationale above and
that the pinned commit SHA now has to stay in sync across four
locations on a future resync (two lines inside `idd-policy.md` itself,
`.claude/settings.json`'s allow-list from #43, and this workflow file).

One note on the issue's own stated rationale for `pull_request`-only:
it says a `push` workflow filtered to a branch glob would skip
`issue/*` branches, but `lint.yml`'s actual `push:` trigger carries no
branch filter today, so that specific risk doesn't currently describe
this repository. Implementing the issue's literal instruction anyway
(`on: pull_request` only) — the practical effect is that this gate runs
on pull requests but not on direct pushes to `main`.

Closes #46
