### PR TITLE
ci: host the idd-advisory-convergence workflow

### DIFF
--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -1,0 +1,45 @@
+name: IDD advisory-convergence gate
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to re-check (e.g. after posting a maintainer waiver)
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  idd-advisory-convergence:
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Trusted default-branch checkout, never the PR head, for any
+          # trigger type including workflow_dispatch -- a PR must not be
+          # able to edit its own verdict logic or .github/idd/config.json
+          # to force this check green. --pr below still evaluates the
+          # right PR: every live API call is driven by that flag, not by
+          # what's checked out locally.
+          ref: main
+          persist-credentials: false
+      - name: Run advisory-convergence verdict (--assert)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          npx --yes --package
+          https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d
+          idd-advisory-convergence
+          --pr ${{ github.event.pull_request.number || inputs.pr_number }}
+          --assert

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -197,5 +197,6 @@ on every upstream bump. `ephemeral-npx` avoids both costs.
   past the 24h deadline has no waiver available, only the underlying
   advisory review actually converging. Posting a waiver comment, once
   the escape hatch is enabled, does not by itself re-run the check —
-  a fresh trigger (push, review, review-comment activity, or
-  `workflow_dispatch`) still has to fire.
+  a fresh trigger (a `pull_request` synchronize, review or
+  review-comment activity, or `workflow_dispatch`) still has to fire;
+  this workflow has no `push` trigger.

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -169,3 +169,33 @@ on every upstream bump. `ephemeral-npx` avoids both costs.
   guards against structurally cannot occur there. Enforcement for that
   rule stays local, via `.githooks/pre-commit`/`pre-push` and a
   developer's own `idd-doctor --strict` run.
+- `.github/workflows/idd-advisory-convergence.yml` (#47) resolves its
+  `idd-advisory-convergence` invocation from the same pinned spec — the
+  commit SHA now has to stay in sync across five locations on a future
+  resync, the four above plus this workflow file. This workflow is
+  **hosted but not yet registered as a required check**: no
+  ruleset exists on this repository today (`gh api
+  repos/{owner}/{repo}/rulesets` returns `[]`), so a maintainer who
+  wants to enforce it opens Settings → Rules → Rulesets → New branch
+  ruleset, targets `main`, enables "Require status checks to pass", and
+  adds `idd-advisory-convergence` (the job id) to the required-checks
+  list — this creates the repository's first ruleset rather than
+  editing an existing one.
+  `--assert` exits non-zero for any not-ready verdict, including the
+  ordinary "Copilot has not reviewed this HEAD yet" pending case —
+  GitHub Actions has no distinct non-failing "pending" state, so this
+  check legitimately shows red until the advisory review converges.
+  This is by design, not a failure to fix.
+  The waiver escape path after `advisoryWait.convergenceDeadline` (24h
+  from the HEAD commit timestamp) only exists once
+  `ciGate.externalCheckWaivers.mode` is `maintainer-authorized` (not its
+  default, `disabled`) and `idd-advisory-convergence` is listed under
+  `ciGate.externalChecks.waivable`. **Neither precondition is met
+  today**: `ciGate` is absent from `.github/idd/config.json` entirely,
+  so both default closed. A maintainer who wants the escape hatch has
+  to add both keys explicitly; until then, a stuck not-ready verdict
+  past the 24h deadline has no waiver available, only the underlying
+  advisory review actually converging. Posting a waiver comment, once
+  the escape hatch is enabled, does not by itself re-run the check —
+  a fresh trigger (push, review, review-comment activity, or
+  `workflow_dispatch`) still has to fire.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/idd-advisory-convergence.yml`, adapted from
`idd-skill`'s `idd-template/.github/workflows/idd-advisory-convergence.yml`
stub (fetched at the pinned commit, not guessed): `ubuntu-slim` runner
and the same `actions/checkout` pin `lint.yml`/`idd-doctor.yml` use,
`ref: main` (never the PR head, for any trigger type including
`workflow_dispatch`) with `persist-credentials: false`, and the helper
invoked through the pinned `ephemeral-npx` spec with `--pr` and
`--assert` instead of `node scripts/advisory-convergence.mjs` +
`actions/setup-node`. No Node-floor-assertion step: that step in
upstream's own dogfooded copy exists to match `package.json`'s
`engines.node`, and this repository has no `package.json`. No
concurrency group: neither the issue's instruction list nor the
adopter-facing template stub includes one — only `idd-skill`'s own
dogfooded copy does, and its own header comments document that the
group doesn't eliminate the race it targets and introduces a separate
stale-rollup issue with no mechanical fix, so adding it here would
import a known footgun for no acceptance-criteria benefit.

Verified against two real PRs in this repository before committing:
PR #70 (an `idd`-claimed branch) resolves `applicability: applicable`,
`converged: true`, `ready: true`; PR #65 (Dependabot, claimless)
resolves `applicability: not_applicable` — confirming the
`idd-claimed` convergence scope decided in #42 behaves as intended and
that the workflow produces a real verdict rather than erroring.

Records in `docs/idd-policy.md`: the check is hosted but **not yet
registered as required** (no ruleset exists on this repository today —
verified via the rulesets API), the exact maintainer Ruleset
registration step, why `--assert` legitimately shows red until
Copilot's review converges (GitHub Actions has no distinct
non-failing "pending" state), and that the waiver escape path is
currently **inactive** — `ciGate` is entirely absent from
`.github/idd/config.json`, so both of its preconditions
(`externalCheckWaivers.mode` and the `externalChecks.waivable` list)
default closed.

Closes #47


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated advisory-convergence checks for pull request activity, reviews, comments, and manual runs.
  - Checks can target the relevant pull request using a trusted, read-only execution context.

- **Documentation**
  - Documented workflow setup requirements, pending-review behavior, waiver prerequisites, and retriggering steps.
  - Clarified that the check is currently informational and does not block changes as a required check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->