### PR TITLE
docs: record the four undocumented idd config.json keys

### DIFF
--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -80,9 +80,10 @@ scripts.
   roadmap-driven workflow so far (#48 and its children).
 - Orphan-first policy: `none` (default) — no orphan-first override is
   in effect.
-- Workshop example repository: unset (default) — this repository has
-  not published a `docs/workshop/`, so the `idd-doctor` example-
-  repository back-link check is intentionally skipped.
+- Workshop example repository: `""` (empty string, treated as unset;
+  default) — this repository has not published a `docs/workshop/`, so
+  the `idd-doctor` example-repository back-link check is intentionally
+  skipped.
 - Claude Code permission baseline: installed at `.claude/settings.json`
   (#43), adapted from the opt-in template baseline documented in
   [`docs/permissions.md`](permissions.md#claude-code-permission-baseline).

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -73,6 +73,16 @@ scripts.
   activation step)
 - Labels: see [IDD label set](#idd-label-set) below
 - Claim timing: stale `PT24H` / heartbeat `PT12H` (defaults)
+- Autopilot-suitability floor: `3` (default) — no repository-specific
+  reason to raise or lower the autopilot-selection floor recorded yet.
+- Issue scope: `roadmap-first` (default) — Discover walks the roadmap
+  path first with an orphan fallback, matching this repository's
+  roadmap-driven workflow so far (#48 and its children).
+- Orphan-first policy: `none` (default) — no orphan-first override is
+  in effect.
+- Workshop example repository: unset (default) — this repository has
+  not published a `docs/workshop/`, so the `idd-doctor` example-
+  repository back-link check is intentionally skipped.
 - Claude Code permission baseline: installed at `.claude/settings.json`
   (#43), adapted from the opt-in template baseline documented in
   [`docs/permissions.md`](permissions.md#claude-code-permission-baseline).


### PR DESCRIPTION
## Summary

Adds four bullets to `docs/idd-policy.md`'s Policy decisions list for
`autopilotSuitability.floor` (`3`), `issueScope` (`"roadmap-first"`),
`orphanFirstPolicy` (`"none"`), and `workshop.exampleRepository`
(unset) — all kept at their distributed defaults, none previously
recorded in this file even though `docs/policy-constants.md` (and, for
the workshop key, `docs/customization.md`) already documents them.

This closes the gap the A1.5 completion audit for roadmap #48 found:
every top-level `.github/idd/config.json` key now has a matching
statement in `docs/idd-policy.md`, satisfying roadmap #48's success
criterion 8.

Closes #72
Refs #48
