### PR TITLE
fix: point the ngrok apt source at a suite the repository publishes

### DIFF
--- a/lib/ngrok.sh
+++ b/lib/ngrok.sh
@@ -5,15 +5,17 @@
 set -eu
 cd "$(cd "$(dirname "$0")"; pwd)/.."
 
-# /etc/os-release is an external system file ShellCheck cannot follow.
-# shellcheck source=/dev/null
-. /etc/os-release
-
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo curl -fsSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc -o /etc/apt/keyrings/ngrok.asc
 sudo chmod 0644 /etc/apt/keyrings/ngrok.asc
 
-echo "deb [signed-by=/etc/apt/keyrings/ngrok.asc] https://ngrok-agent.s3.amazonaws.com ${UBUNTU_CODENAME:-$VERSION_CODENAME} main" \
+# ngrok's apt repository publishes Debian suites only, never Ubuntu
+# codenames -- ngrok ships a single static binary with a low glibc
+# floor, so "buster" is the one build it intends every Debian-family
+# distribution (Ubuntu included) to install. This is deliberate, not
+# an oversight: do not interpolate UBUNTU_CODENAME/VERSION_CODENAME
+# here, every Ubuntu codename 404s against this repository.
+echo "deb [signed-by=/etc/apt/keyrings/ngrok.asc] https://ngrok-agent.s3.amazonaws.com buster main" \
   | sudo tee /etc/apt/sources.list.d/ngrok.list >/dev/null
 
 sudo apt-get update


### PR DESCRIPTION
## Summary

`lib/ngrok.sh` built its apt source line from the host's own Ubuntu
codename (`UBUNTU_CODENAME`/`VERSION_CODENAME`), but ngrok's apt
repository publishes Debian suites only — verified live: `buster` and
`bookworm` return HTTP 200, `resolute`/`noble`/`jammy` all 404. Under
`set -eu`, a 404'd `apt-get update` aborts the script, and the broken
`ngrok.list` it leaves behind breaks every subsequent `apt-get update`
on that machine until a human finds and deletes it — `setup` runs this
before `lib/teardown.sh`/`lib/locale.sh`, so a default `./setup` never
reaches locale, timezone, keyboard config, cleanup, or the desktop
layer either.

Hardcodes `buster` (the suite ngrok's own install instructions use,
matching its static binary's glibc floor) with a comment explaining why
a Debian codename appears in an Ubuntu script, so a future reader
doesn't "fix" it back into a 404. Removes the now-unused
`. /etc/os-release` sourcing and its `shellcheck source=/dev/null`
directive — nothing else in the script reads an os-release variable.

Verified end-to-end in an isolated `ubuntu:24.04` Docker container
(not the host, to avoid mutating real system apt state): `apt-get
update` exits 0, `ngrok` installs and resolves on `PATH`.

Closes #49
