### PR TITLE
fix: exempt IDD-reserved labels from the stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,13 @@ jobs:
           days-before-stale: 60
           close-issue-message: StaleBot closed the issue due to prolonged inactivity.
           close-pr-message: StaleBot closed the pull request due to prolonged inactivity.
-          exempt-issue-labels: bug,enhancement
+          # Mirrors labels.roadmapLabelName, labels.blockedByHumanLabelName,
+          # labels.needsDecisionLabelName, and issueAuthoring.authoringLabelName
+          # in .github/idd/config.json (the last defaults to status:authoring;
+          # the repo does not set issueAuthoring explicitly). Every one of
+          # these marks an issue IDD deliberately parks without activity; a
+          # label rename in config.json needs the matching entry updated here.
+          exempt-issue-labels: bug,enhancement,roadmap,status:blocked-by-human,status:needs-decision,status:authoring
           exempt-pr-labels: bug,enhancement
           stale-issue-label: stale
           stale-issue-message: StaleBot marked the issue as stale because there has been no activity.

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -124,6 +124,16 @@ in `docs/policy-constants.md`.
 | `idd:ready` | `approvalSignals.readyLabelName` | defaulted (key absent from `config.json`) | A3.5 issue-author approval gate |
 | `status:authoring` | `issueAuthoring.authoringLabelName` | defaulted (key absent from `config.json`) | Discover authoring guard (A0-T/A0-O/A3) |
 
+`.github/workflows/stale.yml` must exempt `roadmap`,
+`status:blocked-by-human`, `status:needs-decision`, and
+`status:authoring` from its `exempt-issue-labels` (#50): each marks an
+issue IDD deliberately parks without activity — a roadmap stays open by
+design across its whole initiative, and the three hold labels exist
+precisely because a human has not acted yet. The stale bot cannot read
+`.github/idd/config.json`, so the workflow keeps a literal exempt list
+with a comment naming the four policy keys above it mirrors; keep both
+in sync if any of these label names ever changes.
+
 ## Helper runtime (`ephemeral-npx`)
 
 This repository has no `package.json` and no lockfile, ruling out the


### PR DESCRIPTION
## Summary

`.github/workflows/stale.yml` only exempted `bug,enhancement`, so
`roadmap`, `status:blocked-by-human`, `status:needs-decision`, and
`status:authoring` — every one of which marks an issue IDD deliberately
parks without activity — were swept into its 60-day stale / 14-day
close window. An open roadmap already exists in this repository
(marker `setup-ubuntu-roadmap-id`), so this was a live exposure:
silently closing it would strand its children, since nothing would
reference them as a roadmap task list any more and the completion
audit would have no node to audit.

Adds all four IDD-reserved labels to `exempt-issue-labels`, with a
comment naming the `.github/idd/config.json` policy keys they mirror
(`labels.roadmapLabelName`, `labels.blockedByHumanLabelName`,
`labels.needsDecisionLabelName`, `issueAuthoring.authoringLabelName` —
the last a distributed default since the repo doesn't set
`issueAuthoring` explicitly) so a future label rename has a
discoverable counterpart. Leaves `exempt-pr-labels` untouched, since
IDD pull requests are short-lived and carry no reserved label. Records
the constraint in `docs/idd-policy.md` next to the label set.

Closes #50


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented roadmap and decision-blocked items from being automatically marked stale.

* **Documentation**
  * Updated issue-label policy documentation to reflect stale-item exemptions.
  * Documented the need to keep workflow exemptions synchronized with policy label names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->