### PR TITLE
fix: correct the stale tool attributions and config path refs

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -19,11 +19,11 @@ features:
 globRoot: ${cwd}
 ignorePaths:
   - .*ignore
+  - .cspell.config.yml
   - .git
   - .github/CODE_OF_CONDUCT.*
   - .terraform.lock.hcl
   - .vscode/extensions.json
-  - cspell.config.yml
 language: en,ja
 useGitignore: true
 version: "0.2"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,7 @@
     "**/Brewfile.lock.json": true
   },
   "yaml.schemas": {
-    "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/packages/cspell-types/cspell.schema.json": "cspell.config.yml",
+    "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/packages/cspell-types/cspell.schema.json": ".cspell.config.yml",
     "https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json": ".coderabbit.yaml"
   }
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Dev environment preference for the Ubuntu Linux distribution.
 ### Archive tools
 
 - [bzip2](https://github.com/libarchive/bzip2)
-- [p7zip](https://sourceforge.net/projects/p7zip/)
+- [p7zip](https://github.com/ip7z/7zip)
 - [unzip](https://manpages.ubuntu.com/manpages/man1/unzip.1.html)
 - [xz-utils](https://tukaani.org/xz/)
 - [zip](https://manpages.ubuntu.com/manpages/man1/zip.1.html)
@@ -127,6 +127,7 @@ Dev environment preference for the Ubuntu Linux distribution.
 - [LazySSH](https://github.com/Adembc/lazyssh)
 - [mkcert](https://mkcert.dev/)
 - [mosh](https://mosh.org/)
+- [ngrok](https://ngrok.com/)
 - **`.`** [OpenSSH Server & Client](https://www.openssh.org/)
 - [OpenSSL](https://www.openssl.org/)
 - [OpenVPN](https://openvpn.net/)
@@ -173,7 +174,7 @@ Dev environment preference for the Ubuntu Linux distribution.
 - [jq](https://stedolan.github.io/jq/)
 - (B) [pkl](https://pkl-lang.org/)
 - [ripgrep](https://github.com/BurntSushi/ripgrep)
-- **`!`** [yq](https://mikefarah.gitbook.io/yq)
+- **`!`** [yq](https://github.com/kislyuk/yq)
 
 ### Texts editors
 
@@ -191,7 +192,7 @@ Dev environment preference for the Ubuntu Linux distribution.
 - (B) [act](https://github.com/nektos/act)
 - (B) [dive](https://github.com/wagoodman/dive)
 - (B) [k3sup](https://github.com/alexellis/k3sup)
-- (B) [Docker community edition](https://www.docker.com/)
+- [Docker community edition](https://www.docker.com/)
 - (B) [lazydocker](https://github.com/jesseduffield/lazydocker)
 
 ### Others


### PR DESCRIPTION
## Summary

Five stale references corrected:

- README's `yq` entry linked to mikefarah/yq, but `lib/base-install.sh`
  installs apt's kislyuk/yq and already comments so
  ("`# NOTE: The yq from apt is kislyuk/yq.`") — the two disagreed.
- Docker community edition carried a `(B)` Homebrew marker, but
  `lib/docker.sh` installs it from Docker's own apt repository and
  `lib/Brewfile` has no docker entry.
- ngrok was missing from the README's tool inventory entirely, despite
  `lib/ngrok.sh` installing it on every default `./setup`.
- p7zip linked to its dead SourceForge project page; replaced with the
  maintained ip7z/7zip upstream. `cloud-init.yml`'s `p7zip` package name
  is left alone — renaming it to `7zip` would break older Ubuntu
  releases where that name doesn't exist.
- `.vscode/settings.json` and `.cspell.config.yml` both referenced
  `cspell.config.yml` (no leading dot), a filename that doesn't exist —
  the schema mapping never validated the real config, and the config's
  own `ignorePaths` entry excluded nothing. Fixed both, and moved the
  corrected entry back into its alphabetical slot in `ignorePaths`
  (caught in self-review; the pre-existing list was alphabetized and
  the rename-in-place would have left it out of order with no
  functional effect but a needless inconsistency).

Verified independently before committing: `lib/Brewfile` has no
`docker` line; every other `(B)`-marked README entry does have a
matching `brew` line; both corrected URLs resolve; `cloud-init.yml` is
untouched.

Found but out of scope (no acceptance criterion covers it, so not
touched here): `dprint` (README.md, TUI section) is Brewfile-installed
but carries no `(B)` marker — the mirror-image gap of the Docker bug
this issue fixes. Worth a follow-up if the maintainer wants a full
sweep.

Closes #52
