### PR TITLE
fix: size the build VM, fix nuke, and record the kernel pin rationale

### DIFF
--- a/cloud-init.yml
+++ b/cloud-init.yml
@@ -120,6 +120,11 @@ timezone: Asia/Tokyo
 write_files:
   - path: /etc/apt/preferences.d/999-hold-kernel.pref
     content: |
+      # This deliberately blocks kernel package upgrades, including
+      # security updates, to avoid an upgrade-triggered reboot in the
+      # middle of provisioning this disposable build VM. Do not copy
+      # this file onto a long-lived host: it would silently suppress
+      # kernel security updates there too.
       Package: linux-generic*
       Pin: release a=*
       Pin-Priority: -1

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,14 @@ resource "multipass_instance" "build" {
   cloudinit_file = "${path.module}/cloud-init.yml"
   cpus           = 4
   disk           = "12G"
-  name           = "setup-ubuntu"
+  # The provider default (1GiB) is sized for an idle instance, not this
+  # workload: a full apt-get upgrade, ~70 apt packages, a Homebrew
+  # bootstrap of 34 formulae, a mise Node toolchain, and the Docker
+  # engine. 4G matches cpus and gives the Homebrew bootstrap enough
+  # headroom to avoid an OOM that would otherwise surface as an
+  # unexplained mid-install failure.
+  memory = "4G"
+  name   = "setup-ubuntu"
 }
 
 terraform {

--- a/nuke
+++ b/nuke
@@ -8,5 +8,8 @@ rm -f setup-ubuntu.tar
 if command -v terraform >/dev/null 2>&1
 then
   terraform destroy -auto-approve || true
+fi
+if command -v multipass >/dev/null 2>&1
+then
   multipass delete -p setup-ubuntu || true
 fi


### PR DESCRIPTION
Resolves #53.

## What changed

- `main.tf`: set an explicit `memory = "4G"` on `multipass_instance.build` instead of relying on the provider's 1GiB default, which is sized for an idle instance rather than a full `apt-get upgrade`, ~70 apt packages, a Homebrew bootstrap of 34 formulae, a mise Node toolchain, and the Docker engine.
- `nuke`: guard `terraform destroy` on `terraform` and `multipass delete` on `multipass` in two independent `if` blocks, so either tool being absent no longer suppresses the other's cleanup.
- `cloud-init.yml`: record why the kernel pin in `/etc/apt/preferences.d/999-hold-kernel.pref` blocks kernel security updates, why that's acceptable for this disposable build VM, and that it must not be copied onto a long-lived host. The note is written into the deployed preferences file itself (as `#` comment lines), not just the surrounding YAML, so it travels with any copy of the file.

## Verification

- `shellcheck nuke` — passes.
- `terraform fmt -check` — no diff; `terraform validate` — succeeds (both run in an isolated `hashicorp/terraform` Docker container to avoid installing terraform on the host; the container's provider-checksum lock-file bump was reverted afterward so the diff stays scoped to the three intended files).
- `cloud-init.yml` parses as valid YAML; its `packages:` list (70 entries) is unchanged.
- `nuke` exits 0 with neither tool installed, and runs each tool's cleanup independently of the other's presence — verified with stubbed `terraform`/`multipass` entries on `PATH` under all three combinations (multipass-only, terraform-only, neither).
- The `#`-comment convention inside the apt preferences file was checked empirically against the host's real `apt-cache` (isolated via `-o Dir::Etc::Preferences*`): the pin takes effect identically with and without the comment lines. Note: `man 5 apt_preferences` only documents `Explanation:` as the sanctioned in-record comment mechanism, not `#` — this works on the tested apt version (3.2.0) but isn't spec-guaranteed, so it's a minor residual note rather than a blocking concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build instances now have 4 GB of memory allocated for more consistent provisioning.

* **Bug Fixes**
  * Improved cleanup handling so it runs only when Multipass is available.
  * Completed the Terraform availability check.

* **Documentation**
  * Added guidance explaining the security-update limitations of kernel package pinning and its intended use during provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->