### PR TITLE
docs: resync README.ja.md with README.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,6 +24,13 @@ minimum necessary configuration required. Configuration matters are the
 responsibility of the [dotfiles](https://github.com/kurone-kito/dotfiles)
 repository.
 
+## Documentation
+
+`README.md` and `README.ja.md` document the same tool inventory in
+different languages. Any change to the tool inventory in `README.md`
+(adding, removing, or re-describing an installed tool) must update
+`README.ja.md` in the same change, so the two files never drift apart.
+
 ## IDD Workflow
 
 This project uses Issue-Driven Development (IDD) with parallel AI agents.

--- a/README.ja.md
+++ b/README.ja.md
@@ -12,10 +12,17 @@ Ubuntu Linux ディストリビューション向けの開発環境設定です�
 
 ## インストールされるアプリ
 
+|  記号   | 説明                                                                                                                         |
+| :-----: | :--------------------------------------------------------------------------------------------------------------------------- |
+| **`!`** | **依存関係**: これらのアプリを削除すると、このセットアップが正しく動作しなくなる場合があります。                             |
+| **`.`** | **[dotfiles](https://github.com/kurone-kito/dotfiles) の依存関係**: dotfiles を正しく動作させるために必要です。              |
+|   (B)   | [Homebrew](https://brew.sh/) パッケージマネージャー経由でインストールされるため、Homebrew で管理できます。                   |
+|   (M)   | [mise-en-place](https://mise.jdx.dev/) パッケージマネージャー経由でインストールされるため、mise-en-place で管理できます。    |
+
 ### アーカイブツール
 
 - bzip2
-- [p7zip](https://sourceforge.net/projects/p7zip/)
+- [p7zip](https://github.com/ip7z/7zip)
 - unzip
 - xz-utils
 - zip
@@ -33,53 +40,66 @@ Ubuntu Linux ディストリビューション向けの開発環境設定です�
 - [ImageMagick](https://imagemagick.org/index.php)
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp)
 
-#### 設定管理ツール
+### クリップボードツール
 
-- [chezmoi](https://www.chezmoi.io/)
+- [xsel](http://www.kfish.org/software/xsel/)
+- yank
+
+### 設定管理ツール
+
+- **`.`** (M) [Bitwarden CLI](https://bitwarden.com/)
+- **`.`** (B) [chezmoi](https://www.chezmoi.io/)
 
 ### 暗号化
 
-- [GnuPG: The GNU Privacy Guard](https://gnupg.org/)
-- pinentry-curses
+- **`!`** [GnuPG: The GNU Privacy Guard](https://gnupg.org/)
+- **`.`** [pinentry-curses](https://manpages.ubuntu.com/manpages/man1/pinentry-curses.1.html)
 
 ### データベース
 
 - [SQLite](https://www.sqlite.org/)
-- [Taskwarrior](https://taskwarrior.org/)
+- (B) [Taskwarrior](https://taskwarrior.org/)
 
 ### 開発ツール
 
-- build-essential
-- cargo
+- (B) [ast-grep](https://ast-grep.github.io/)
+- **`!`** build-essential
+- **`!`** cargo
+- (B) **`!`** [Cargo Binary Install](https://github.com/cargo-bins/cargo-binstall)
 - [CMake](https://cmake.org)
+- (B) [Deno](https://deno.com/)
+- (B) [direnv](https://direnv.net/)
 - [GCC: the GNU Compiler Collection](https://gcc.gnu.org)
 - make
-- mise
-- python3
+- **`.`** (M) [Node.js](https://nodejs.org/)
+- (B) python3
+- (B) [tree-sitter](https://tree-sitter.github.io/tree-sitter/)
 
 ### ダウンロードツール
 
-- ca-certificates
-- [curl](https://curl.se)
-- httpie
+- **`!`** ca-certificates
+- **`!`** [curl](https://curl.se)
 - [GNU wget](https://www.gnu.org/software/wget/)
 
 ### ファイル管理
 
 - [bat](https://github.com/sharkdp/bat)
 - eza
-- fd
+- (B) fd
 - [fzf](https://github.com/junegunn/fzf)
 - [rename](http://plasmasturm.org/code/rename/)
-- zoxide
+- [trash-cli](https://github.com/andreafrancia/trash-cli)
+- (B) [watchexec](https://github.com/watchexec/watchexec)
+- (B) [yazi](https://yazi-rs.github.io/)
+- **`.`** zoxide
 
 #### 生成 AI
 
-- [Ollama](https://ollama.com/)
+- (B) [Ollama](https://ollama.com/)
 
 ### ハードウェア
 
-- keyboard-configuration
+- **`!`** keyboard-configuration
 
 ### ジョーク
 
@@ -88,55 +108,58 @@ Ubuntu Linux ディストリビューション向けの開発環境設定です�
 
 ### ロケール
 
-- language-pack-ja
+- **`!`** language-pack-ja
 
 ### パッケージマネージャー
 
 - apt-file
 - apt-transport-https
 - apt-utils
-- [Homebrew](https://brew.sh/)
-- software-properties-common
-- vrc-get
+- **`!`** [Homebrew](https://brew.sh/)
+- **`!`** (B) [mise-en-place](https://mise.jdx.dev/)
+- **`!`** software-properties-common
+- **`.`** (B) vrc-get
 
 ### リモートツール
 
-- [awscli](https://aws.amazon.com/cli/)
+- **`.`** (B) [awscli](https://aws.amazon.com/cli/)
+- [httpie](https://httpie.io/)
+- [LazySSH](https://github.com/Adembc/lazyssh)
 - [mkcert](https://mkcert.dev/)
 - mosh
-- OpenSSH Server & Client
+- [ngrok](https://ngrok.com/)
+- **`.`** [OpenSSH Server & Client](https://www.openssh.org/)
 - OpenSSL
 - [OpenVPN](https://openvpn.net/)
 - [rsync](https://rsync.samba.org/)
 
 ### SCM ツール
 
-- [ghq](https://github.com/x-motemen/ghq)
-- [GitHub CLI](https://cli.github.com/)
-- [Gist](http://defunkt.io/gist/)
-- [Git](https://git-scm.com/)
-- [git-delta: A viewer for git and diff output](https://github.com/dandavison/delta)
-- [Git Large File Storage](https://git-lfs.github.com/)
-- [gti](https://r-wos.org/hacks/gti)
-- [Jujutsu](https://jj-vcs.dev/)
-- [lazygit](https://github.com/jesseduffield/lazygit)
-- [lazyjj](https://github.com/Cretezy/lazyjj)
+- **`.`** (B) [ghq](https://github.com/x-motemen/ghq)
+- **`.`** [GitHub CLI](https://cli.github.com/)
+- **`.`** [Git](https://git-scm.com/)
+- **`.`** [git-delta: A viewer for git and diff output](https://github.com/dandavison/delta)
+- **`.`** [Git Large File Storage](https://git-lfs.github.com/)
+- (B) [gti](https://r-wos.org/hacks/gti)
+- (B) [Jujutsu](https://jj-vcs.dev/)
+- (B) [lazygit](https://github.com/jesseduffield/lazygit)
+- (B) [lazyjj](https://github.com/Cretezy/lazyjj)
 - [Apache Subversion](https://subversion.apache.org/)
+- (B) [Worktrunk](https://worktrunk.dev/)
 
 ### シェルユーティリティ
 
 - bash-completion
-- [Microsoft PowerShell](https://microsoft.com/PowerShell)
-- rebound
+- **`.`** (B) [Microsoft PowerShell](https://microsoft.com/PowerShell)
 - [shellcheck](https://www.shellcheck.net)
+- **`.`** (B) [Starship](https://starship.rs/)
 - sudo-rs
 - [The Fuck](https://github.com/nvbn/thefuck)
-- yank
-- zsh
-- zsh-theme-powerlevel9k
+- **`.`** [zsh](https://www.zsh.org/)
 
 ### テキストブラウジングツール
 
+- (B) [glow](https://github.com/charmbracelet/glow)
 - links2
 - [mdp](https://github.com/visit1985/mdp)
 - tealdeer
@@ -145,27 +168,32 @@ Ubuntu Linux ディストリビューション向けの開発環境設定です�
 ### テキスト変換ツール
 
 - [cloc](https://github.com/AlDanial/cloc)
+- [dprint](https://dprint.dev/)
 - [groff](https://www.gnu.org/software/groff/)
 - [jc](https://kellyjonbrazil.github.io/jc/)
 - [jq](https://stedolan.github.io/jq/)
+- (B) [pkl](https://pkl-lang.org/)
 - [ripgrep](https://github.com/BurntSushi/ripgrep)
-- [yq](https://mikefarah.gitbook.io/yq)
+- **`!`** [yq](https://github.com/kislyuk/yq)
 
 ### テキストエディター
 
-- [GNU Nano](https://www.nano-editor.org)
-- [Neovim](https://neovim.io/)
-- [Vim](https://www.vim.org/)
+- (B) [Microsoft Edit](https://github.com/microsoft/edit)
+- **`.`** (B) [Neovim](https://neovim.io/)
+- **`.`** [Vim](https://www.vim.org/)
 
 ### TUI
 
-- [byobu](https://www.byobu.org/)
-- [tmux](https://github.com/tmux/tmux)
-- [zellij](https://zellij.dev)
+- **`.`** [tmux](https://github.com/tmux/tmux)
+- **`.`** (B) [zellij](https://zellij.dev)
 
 #### 仮想化
 
-- Docker community edition
+- (B) [act](https://github.com/nektos/act)
+- (B) [dive](https://github.com/wagoodman/dive)
+- (B) [k3sup](https://github.com/alexellis/k3sup)
+- [Docker community edition](https://www.docker.com/)
+- (B) [lazydocker](https://github.com/jesseduffield/lazydocker)
 
 ### その他
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -43,7 +43,7 @@ Ubuntu Linux ディストリビューション向けの開発環境設定です�
 ### クリップボードツール
 
 - [xsel](http://www.kfish.org/software/xsel/)
-- yank
+- [yank](https://github.com/mptre/yank)
 
 ### 設定管理ツール
 
@@ -64,7 +64,7 @@ Ubuntu Linux ディストリビューション向けの開発環境設定です�
 
 - (B) [ast-grep](https://ast-grep.github.io/)
 - **`!`** build-essential
-- **`!`** cargo
+- **`!`** [cargo](https://doc.rust-lang.org/stable/cargo/)
 - (B) **`!`** [Cargo Binary Install](https://github.com/cargo-bins/cargo-binstall)
 - [CMake](https://cmake.org)
 - (B) [Deno](https://deno.com/)
@@ -72,12 +72,12 @@ Ubuntu Linux ディストリビューション向けの開発環境設定です�
 - [GCC: the GNU Compiler Collection](https://gcc.gnu.org)
 - make
 - **`.`** (M) [Node.js](https://nodejs.org/)
-- (B) python3
+- (B) [python3](https://www.python.org/)
 - (B) [tree-sitter](https://tree-sitter.github.io/tree-sitter/)
 
 ### ダウンロードツール
 
-- **`!`** ca-certificates
+- **`!`** [ca-certificates](https://curl.se/docs/caextract.html)
 - **`!`** [curl](https://curl.se)
 - [GNU wget](https://www.gnu.org/software/wget/)
 
@@ -85,13 +85,13 @@ Ubuntu Linux ディストリビューション向けの開発環境設定です�
 
 - [bat](https://github.com/sharkdp/bat)
 - eza
-- (B) fd
+- (B) [fd](https://github.com/sharkdp/fd)
 - [fzf](https://github.com/junegunn/fzf)
 - [rename](http://plasmasturm.org/code/rename/)
 - [trash-cli](https://github.com/andreafrancia/trash-cli)
 - (B) [watchexec](https://github.com/watchexec/watchexec)
 - (B) [yazi](https://yazi-rs.github.io/)
-- **`.`** zoxide
+- **`.`** [zoxide](https://crates.io/crates/zoxide)
 
 #### 生成 AI
 
@@ -118,7 +118,7 @@ Ubuntu Linux ディストリビューション向けの開発環境設定です�
 - **`!`** [Homebrew](https://brew.sh/)
 - **`!`** (B) [mise-en-place](https://mise.jdx.dev/)
 - **`!`** software-properties-common
-- **`.`** (B) vrc-get
+- **`.`** (B) [vrc-get](https://github.com/vrc-get/vrc-get)
 
 ### リモートツール
 


### PR DESCRIPTION
Resolves #54.

## What changed

- `README.ja.md`: brought the tool inventory back into structural and factual parity with `README.md`:
  - Added the tools missing from the Japanese copy. The issue's own list named 23, but it omitted `ngrok`; this PR adds all 24.
  - Removed the 5 tools no longer installed (byobu, gist, powerlevel9k, nano, rebound).
  - Added a translated legend table (right after "## インストールされるアプリ") defining every `!`/`.`/(B)/(M) marker used in the body — this table didn't exist in the Japanese copy before.
  - Added the missing "Clipboard tools" section (xsel, yank — yank moved here from Shell utilities to match README.md).
  - Matched README.md's `###`/`####` section set and order exactly (24 tool-inventory sections).
  - Corrected the `yq`, Docker, `ngrok`, and `p7zip` entries to agree with the already-corrected `README.md` (from #52).
  - Left existing Japanese prose and formatting conventions elsewhere untouched — this is a resync, not a retranslation.
- `.github/copilot-instructions.md`: added a "Documentation" section stating that a change to the tool inventory in `README.md` must update `README.ja.md` in the same change.

No community document under `.github/` (CODE_OF_CONDUCT, CONTRIBUTING) was touched.

## Verification

- `npx -y markdownlint-cli2 "**/*.md"` — 0 issues (58 files).
- `npx -y cspell lint "**" --no-progress` — 0 issues (97 files).
- Every tool entry and its `!`/`.`/(B)/(M) marker set was cross-checked 1:1 against `README.md` by an independent review pass (entry-by-entry, not sampled) — no mismatches.
- The two files' tool-inventory section sequences (name, heading level, and order) were verified to match exactly.
- A stray full-width→half-width parenthesis slip in the unrelated "Desktop" section, introduced while rewriting the file and caught by the independent review, was reverted before this commit — the diff is scoped to the tool inventory, the legend, and `copilot-instructions.md` only.
