### PR TITLE
feat: report per-stage progress and a failure summary from setup

### DIFF
--- a/setup
+++ b/setup
@@ -94,18 +94,53 @@ then
   exit 0
 fi
 
+log() { printf '[setup] %s\n' "$*"; }
+
+CURRENT_STAGE=""
+COMPLETED_STAGES=""
+
+# Announces a stage before running it, and records it as completed
+# afterward so a failure can report what a re-run would repeat.
+run_stage() {
+  CURRENT_STAGE="$1"
+  log "starting: ${CURRENT_STAGE}"
+  "$1"
+  if [ -z "$COMPLETED_STAGES" ]
+  then
+    COMPLETED_STAGES="$1"
+  else
+    COMPLETED_STAGES="${COMPLETED_STAGES}, $1"
+  fi
+  CURRENT_STAGE=""
+}
+
+# Runs on every exit from the native install sequence below, including an
+# interrupt (via the INT/TERM/HUP trap's exit). CURRENT_STAGE is only
+# non-empty here if the shell exited while a stage was in flight, so a
+# clean finish or an early exit elsewhere in this script prints nothing.
+report_failure() {
+  status=$?
+  if [ -n "$CURRENT_STAGE" ]
+  then
+    log "stage failed: ${CURRENT_STAGE}"
+    log "stages completed before the failure: ${COMPLETED_STAGES:-none}"
+  fi
+  kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
+  exit "$status"
+}
+
 sudo -v
 while true; do sleep 30; sudo -n true; kill -0 "$$" || exit; done 2>/dev/null &
 SUDO_KEEPALIVE_PID=$!
-trap 'kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true' EXIT
+trap report_failure EXIT
 trap 'exit 1' INT TERM HUP
-lib/base-install.sh
-lib/homebrew.sh
-lib/mise.sh
-lib/docker.sh
-lib/ngrok.sh
-lib/teardown.sh
-lib/locale.sh
+run_stage lib/base-install.sh
+run_stage lib/homebrew.sh
+run_stage lib/mise.sh
+run_stage lib/docker.sh
+run_stage lib/ngrok.sh
+run_stage lib/teardown.sh
+run_stage lib/locale.sh
 
 if [ "$USE_DESKTOP" -eq 1 ]
 then


### PR DESCRIPTION
Resolves #55.

## What changed

`setup` only (no `lib/` file is touched):

- Added a `log()` helper with a `[setup]` prefix, matching the existing `[desktop]` convention already used by `lib/desktop.sh`'s own `log()` helper.
- Wrapped each stage of the native install sequence (`lib/base-install.sh`, `lib/homebrew.sh`, `lib/mise.sh`, `lib/docker.sh`, `lib/ngrok.sh`, `lib/teardown.sh`, `lib/locale.sh`) in a `run_stage` function that announces the stage before running it and records it into a completed-stages list afterward.
- Replaced the bare `kill "$SUDO_KEEPALIVE_PID"` `EXIT` trap body with `report_failure`, which additionally reports which stage failed and which stages completed before it — but only when a stage was actually in flight at exit time, so a clean finish, `--dry-run`, the VM path, or the optional `--desktop` stage print no summary. This relies on the `EXIT`/`INT`/`TERM`/`HUP` trap split from #51, which is unchanged.

## Verification

- `shellcheck setup nuke lib/*.sh` — passes.
- `git status` confirms no file under `lib/` was modified.
- `--dry-run` and the VM path produce byte-identical output to the pre-change script (compared directly against the committed HEAD version).
- An isolated `dash` harness mirroring the exact `run_stage`/`report_failure`/trap logic verified: a normal run announces every stage and prints no summary, exiting 0; a failing stage reports the correct failed-stage name and the correct completed-stages list while preserving the original nonzero exit status; sending `SIGINT` to the whole process group while a stage is blocked produces the same summary with no orphaned processes left behind afterward (checked by PGID, not just command name, since this sandbox has unrelated background jobs from other tasks running concurrently).

**Known pre-existing limitation (not introduced by this change, not required by the acceptance criteria):** the sudo-keepalive loop's in-flight `sleep 30` child can take up to ~30s to exit on its own after an interrupt, since the loop's own exit check only runs between sleeps. This is unchanged from before #55 and out of this issue's scope.
