### PR TITLE
test: add a non-mutating smoke test for the setup CLI surface

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,13 @@ jobs:
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe # v24.1.0
       - name: Run shellcheck
-        # Lints setup and nuke (detected via their #!/bin/sh shebang) and
-        # lib/*.sh; .githooks is upstream-managed template code and excluded.
+        # Lints setup and nuke (detected via their #!/bin/sh shebang),
+        # lib/*.sh, and tests/*.sh; .githooks is upstream-managed template
+        # code and excluded.
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           ignore_paths: .githooks
+      - name: Run the setup CLI smoke test
+        run: ./tests/setup-cli.test.sh
       - name: Run actionlint
         uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0

--- a/tests/setup-cli.test.sh
+++ b/tests/setup-cli.test.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# -*- mode: sh -*-
+# vim: set ft=sh :
+
+# Non-mutating smoke test for setup's CLI argument surface. Every case here
+# reaches its outcome before setup would install anything or invoke sudo, so
+# this test runs the real ./setup directly rather than mocking its parser.
+
+set -eu
+cd "$(cd "$(dirname "$0")/.."; pwd)"
+
+# Clear the desktop env vars so an ambient value from the caller's
+# environment cannot change a case's expected outcome.
+unset DESKTOP_DRY_RUN DESKTOP_SUNSHINE_WSL DESKTOP_DUMMY_DISPLAY
+
+FAILURES=0
+
+# Runs setup with the given arguments/environment and checks the exit status
+# and a distinguishing (not exact-wording) output substring.
+check() {
+  name="$1"
+  expected_status="$2"
+  expected_substring="$3"
+  shift 3
+
+  set +e
+  output="$("$@" 2>&1)"
+  actual_status=$?
+  set -e
+
+  ok=1
+  if [ "${actual_status}" -ne "${expected_status}" ]
+  then
+    ok=0
+    printf 'FAIL: %s: expected exit %s, got %s\n' "${name}" "${expected_status}" "${actual_status}" >&2
+  fi
+  if ! printf '%s\n' "${output}" | grep -qF "${expected_substring}"
+  then
+    ok=0
+    printf 'FAIL: %s: expected output to contain %s\n' "${name}" "${expected_substring}" >&2
+  fi
+  if [ "${ok}" -eq 1 ]
+  then
+    printf 'PASS: %s\n' "${name}"
+  else
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+check "help (-h)" 0 "Usage:" ./setup -h
+check "help (--help)" 0 "Usage:" ./setup --help
+check "unknown flag" 1 "Usage:" ./setup --not-a-real-flag
+check "stray positional after --" 1 "Usage:" ./setup -- extra-positional
+check "--dry-run" 0 "[desktop:plan]" ./setup --dry-run
+check "DESKTOP_DRY_RUN=true env var" 0 "[desktop:plan]" env DESKTOP_DRY_RUN=true ./setup
+check "--desktop -v rejected on the VM path" 1 "not supported" ./setup --desktop -v
+check "--desktop -v --dry-run is exempt" 0 "[desktop:plan]" ./setup --desktop -v --dry-run
+
+if [ "${FAILURES}" -gt 0 ]
+then
+  printf '%s case(s) failed\n' "${FAILURES}" >&2
+  exit 1
+fi
+
+echo "all setup CLI smoke test cases passed"


### PR DESCRIPTION
Resolves #56.

## What changed

- `tests/setup-cli.test.sh` (new): a POSIX `sh` smoke test invoking the real `./setup` for every case in the CLI surface that resolves before any install stage or `sudo` call:
  - `-h`/`--help`
  - an unknown flag
  - a stray positional argument after `--`
  - `--dry-run`
  - `DESKTOP_DRY_RUN=true` (env var, string-normalized)
  - `--desktop -v` (rejected on the VM path)
  - `--desktop -v --dry-run` (exempt from that rejection)

  Each case asserts exit status plus a short, distinguishing output substring (`Usage:`, `[desktop:plan]`, `not supported`) rather than exact message wording, so an ordinary message edit doesn't break the test. The environment is cleared of `DESKTOP_DRY_RUN`/`DESKTOP_SUNSHINE_WSL`/`DESKTOP_DUMMY_DISPLAY` first so an ambient value from the caller's shell can't change a case's expected outcome.
- `.github/workflows/lint.yml`: added a step running the new test, and updated the shellcheck step's comment to note it now also lints `tests/*.sh`.

## Verification

- `shellcheck setup nuke lib/*.sh tests/setup-cli.test.sh` — passes.
- `actionlint` — passes.
- `npx -y markdownlint-cli2 "**/*.md"` and `npx -y cspell lint "**" --no-progress` — both pass.
- The test runs clean under `dash` both with and without an ambient `DESKTOP_DRY_RUN` set (confirming the environment-clearing fix actually prevents the false-positive/false-negative risk it targets).
- A scratch copy of the test with a deliberately wrong expectation (never committed) confirmed the failure-reporting path: it printed the failing case by name and exited non-zero, while every other case still ran and passed.
- Traced `setup`'s control flow by hand for all 8 checks: none reach `sudo -v`, `lib/virtual.sh`, `lib/deploy.sh`, or any native install stage — the test installs nothing and never invokes `sudo`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated smoke tests covering setup command help, invalid arguments, dry-run behavior, environment variables, and desktop options.
  * Tests now report individual results and fail clearly when a scenario does not pass.

* **Chores**
  * Expanded shell script linting coverage and added the setup smoke test to the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->