### PR TITLE
feat: install the Unity CLI in the default setup path

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -93,6 +93,10 @@ Ubuntu Linux ディストリビューション向けの開発環境設定です�
 - (B) [yazi](https://yazi-rs.github.io/)
 - **`.`** [zoxide](https://crates.io/crates/zoxide)
 
+### ゲーム開発
+
+- [Unity CLI](https://docs.unity.com/en-us/unity-cli)
+
 #### 生成 AI
 
 - (B) [Ollama](https://ollama.com/)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Dev environment preference for the Ubuntu Linux distribution.
 - (B) [yazi](https://yazi-rs.github.io/)
 - **`.`** [zoxide](https://crates.io/crates/zoxide)
 
+### Game development
+
+- [Unity CLI](https://docs.unity.com/en-us/unity-cli)
+
 #### Generative AI
 
 - (B) [Ollama](https://ollama.com/)

--- a/lib/unity.sh
+++ b/lib/unity.sh
@@ -12,4 +12,10 @@ cd "$(cd "$(dirname "$0")"; pwd)/.."
 UNITY_CLI_CHANNEL=beta
 export UNITY_CLI_CHANNEL
 
-curl -fsSL https://public-cdn.cloud.unity3d.com/hub/prod/cli/install.sh | bash -
+# Download to a temp file first: `curl ... | bash -` would let a failed
+# curl exit the pipeline at 0 (bash runs on an empty stdin), silently
+# skipping the install instead of failing this stage.
+installer="$(mktemp)"
+trap 'rm -f "$installer"' EXIT
+curl -fsSL https://public-cdn.cloud.unity3d.com/hub/prod/cli/install.sh -o "$installer"
+bash "$installer"

--- a/lib/unity.sh
+++ b/lib/unity.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# -*- mode: sh -*-
+# vim: set ft=sh :
+
+set -eu
+cd "$(cd "$(dirname "$0")"; pwd)/.."
+
+# Unity has not published a stable release manifest yet (the stable
+# manifest 404s); the beta channel is the only one that currently
+# resolves. Pinned in this one place so it can be dropped once Unity
+# publishes a stable manifest.
+UNITY_CLI_CHANNEL=beta
+export UNITY_CLI_CHANNEL
+
+curl -fsSL https://public-cdn.cloud.unity3d.com/hub/prod/cli/install.sh | bash -

--- a/setup
+++ b/setup
@@ -139,6 +139,7 @@ run_stage lib/homebrew.sh
 run_stage lib/mise.sh
 run_stage lib/docker.sh
 run_stage lib/ngrok.sh
+run_stage lib/unity.sh
 run_stage lib/teardown.sh
 run_stage lib/locale.sh
 


### PR DESCRIPTION
Resolves #58.

## What changed

- `lib/unity.sh` (new): installs Unity's official standalone CLI via its vendor `install.sh`, pinned to the `beta` release channel — Unity has not published a stable release manifest yet (`latest.json` 404s; `latest-beta.json` currently resolves). The channel appears in exactly one place in the repository, with the reason for the pin recorded next to it.
- `setup`: calls `lib/unity.sh` on the real-Ubuntu path, between `lib/ngrok.sh` and `lib/teardown.sh`. The VM/non-Ubuntu path is unchanged.
- `README.md` / `README.ja.md`: list the Unity CLI under a new `### Game development` / `### ゲーム開発` section, positioned between `Files management`/`ファイル管理` and the `Generative AI`/`生成 AI` subsection to keep the existing alphabetical ordering, linking to Unity's official CLI documentation (`https://docs.unity.com/en-us/unity-cli`).

## Verification

- `shellcheck setup nuke lib/*.sh tests/setup-cli.test.sh` — passes.
- `npx -y markdownlint-cli2 "**/*.md"` and `npx -y cspell lint "**" --no-progress` — both pass (no new vocabulary needed).
- The #56 CLI smoke test (`tests/setup-cli.test.sh`) still passes unchanged, since this diff doesn't touch the `--dry-run`/VM paths it covers.
- The installer's actual behavior was verified empirically in an isolated Docker container (`ubuntu:24.04`, non-root user, no `sudo` installed):
  - `unity --version` succeeds in a freshly started shell (both a login shell and a plain interactive non-login shell) with no manual `PATH` fix-up.
  - Running the installer a second time succeeds and adds no duplicate `PATH` entry to `~/.bashrc` — confirmed via the installer's own exact-line-match guard, not merely because `PATH` was already set from the first run.
  - No step requires `sudo` or a TTY/interactive prompt — read through the vendor installer's full source to confirm, and the container user had no elevated privileges available.
