### PR TITLE
feat: install the pinned Unity Editors behind a --unity opt-in flag

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -58,6 +58,7 @@ words:
   - unwaived
   - vaapi
   - vainfo
+  - vrchat
   - waivable
   - xkblayout
   - xkbmodel

--- a/lib/unity-editors.sh
+++ b/lib/unity-editors.sh
@@ -45,20 +45,38 @@ VRCHAT_CHANGESET="887be4894c44"
 # of jq: this script can run before base-install.sh (a bare --unity
 # --dry-run only needs the CLI, already required above), so jq is not
 # guaranteed to be on PATH yet.
+#
+# Both helpers fail loudly with a targeted message when the field is
+# missing/renamed, rather than a bare failed pipeline aborting the
+# script under `set -e` with no explanation.
 json_field() {
-  printf '%s' "$1" | grep -o "\"$2\":[[:space:]]*\"[^\"]*\"" | head -1 | sed 's/.*"\([^"]*\)"$/\1/'
+  value="$(printf '%s' "$1" | grep -o "\"$2\":[[:space:]]*\"[^\"]*\"" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
+  if [ -z "$value" ]
+  then
+    echo "Error: could not find a \"$2\" string field in the unity CLI's JSON output. Its output format may have changed." >&2
+    exit 1
+  fi
+  printf '%s' "$value"
 }
 
 json_number_field() {
-  printf '%s' "$1" | grep -o "\"$2\":[[:space:]]*[0-9]*" | head -1 | grep -o '[0-9]*$'
+  value="$(printf '%s' "$1" | grep -o "\"$2\":[[:space:]]*[0-9]*" | head -1 | grep -o '[0-9]*$' || true)"
+  if [ -z "$value" ]
+  then
+    echo "Error: could not find a \"$2\" numeric field in the unity CLI's JSON output. Its output format may have changed." >&2
+    exit 1
+  fi
+  printf '%s' "$value"
 }
 
 resolve() {
   # $1 = version selector, $2 = changeset (empty if none)
+  # -m takes every module in one variadic flag (not one -m per module);
+  # word-splitting $MODULES is intentional to pass them as separate
+  # arguments to that one flag, since this script is POSIX sh and a bash
+  # array is not available.
   if [ -n "$2" ]
   then
-    # Word-splitting $MODULES is intentional: each module is its own -m
-    # argument, and this script is POSIX sh so a bash array is not available.
     # shellcheck disable=SC2086
     unity install "$1" -c "$2" --dry-run --non-interactive --yes --json -m $MODULES --cm
   else
@@ -113,9 +131,12 @@ then
   exit 1
 fi
 
+# Installs the exact version validated above, not the selector: re-passing
+# the selector here could resolve to a different (newer) release if one
+# shipped between the resolve call and this one.
 log "installing general-games Editor ${general_version}..."
 # shellcheck disable=SC2086
-unity install "$GENERAL_SELECTOR" --non-interactive --yes --accept-eula -m $MODULES --cm
+unity install "$general_version" --non-interactive --yes --accept-eula -m $MODULES --cm
 
 log "installing VRChat Editor ${vrchat_version}..."
 # shellcheck disable=SC2086

--- a/lib/unity-editors.sh
+++ b/lib/unity-editors.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# -*- mode: sh -*-
+# vim: set ft=sh :
+
+set -eu
+cd "$(cd "$(dirname "$0")"; pwd)/.."
+
+log() { printf '[unity] %s\n' "$*"; }
+plan() { printf '[unity:plan] %s\n' "$*"; }
+
+if ! command -v unity >/dev/null 2>&1
+then
+  echo "Error: the unity CLI is not on PATH. Run ./setup once (without --dry-run) first so lib/unity.sh installs it." >&2
+  exit 1
+fi
+
+DRY_RUN=0
+if [ "${1:-}" = "--dry-run" ]
+then
+  DRY_RUN=1
+fi
+
+# Measured against Unity's release API for LINUX/X86_64: both pinned
+# Editors with the modules below total ~27 GiB installed. Kept as a
+# single constant so the preflight threshold has one place to update.
+REQUIRED_DISK_GIB=30
+
+# Modules shared by both Editors. windows-mono is required for VRChat PC
+# content, which builds as StandaloneWindows64.
+MODULES="android linux-il2cpp windows-mono"
+
+# The 6.3 stream has to be selected explicitly: Unity's "lts" alias is
+# ambiguous between the 6000.0 and 6000.3 lines and can resolve to
+# whichever line was patched most recently.
+GENERAL_SELECTOR="6.3"
+GENERAL_PREFIX="6000.3."
+
+# The exact build VRChat's SDK targets. It is old enough that Unity's
+# release list may not carry it by version alone, so the changeset pins
+# the install either way.
+VRCHAT_VERSION="2022.3.22f1"
+VRCHAT_CHANGESET="887be4894c44"
+
+# `unity install --dry-run --json` output is parsed with grep/sed instead
+# of jq: this script can run before base-install.sh (a bare --unity
+# --dry-run only needs the CLI, already required above), so jq is not
+# guaranteed to be on PATH yet.
+json_field() {
+  printf '%s' "$1" | grep -o "\"$2\":[[:space:]]*\"[^\"]*\"" | head -1 | sed 's/.*"\([^"]*\)"$/\1/'
+}
+
+json_number_field() {
+  printf '%s' "$1" | grep -o "\"$2\":[[:space:]]*[0-9]*" | head -1 | grep -o '[0-9]*$'
+}
+
+resolve() {
+  # $1 = version selector, $2 = changeset (empty if none)
+  if [ -n "$2" ]
+  then
+    # Word-splitting $MODULES is intentional: each module is its own -m
+    # argument, and this script is POSIX sh so a bash array is not available.
+    # shellcheck disable=SC2086
+    unity install "$1" -c "$2" --dry-run --non-interactive --yes --json -m $MODULES --cm
+  else
+    # shellcheck disable=SC2086
+    unity install "$1" --dry-run --non-interactive --yes --json -m $MODULES --cm
+  fi
+}
+
+log "resolving general-games Editor (${GENERAL_SELECTOR})..."
+general_json="$(resolve "$GENERAL_SELECTOR" "")"
+general_version="$(json_field "$general_json" version)"
+
+# Validated before extracting the size field below: under `set -e`, a
+# missing/renamed JSON field would abort this script silently at that
+# extraction, preempting this loud, specific error.
+case "$general_version" in
+  "${GENERAL_PREFIX}"*) ;;
+  *)
+    echo "Error: general-games selector '${GENERAL_SELECTOR}' resolved to '${general_version}', not a ${GENERAL_PREFIX}* build. Unity's 'lts' alias is ambiguous between release lines; refusing to install the wrong stream." >&2
+    exit 1
+    ;;
+esac
+
+general_size="$(json_number_field "$general_json" totalDownloadSize)"
+
+log "resolving VRChat Editor (${VRCHAT_VERSION})..."
+vrchat_json="$(resolve "$VRCHAT_VERSION" "$VRCHAT_CHANGESET")"
+vrchat_version="$(json_field "$vrchat_json" version)"
+
+if [ "$vrchat_version" != "$VRCHAT_VERSION" ]
+then
+  echo "Error: VRChat selector resolved to '${vrchat_version}', expected exactly '${VRCHAT_VERSION}'." >&2
+  exit 1
+fi
+
+vrchat_size="$(json_number_field "$vrchat_json" totalDownloadSize)"
+
+if [ "$DRY_RUN" -eq 1 ]
+then
+  plan "general games: ${general_version} (~$((general_size / 1024 / 1024 / 1024)) GiB download)"
+  plan "VRChat: ${vrchat_version} changeset ${VRCHAT_CHANGESET} (~$((vrchat_size / 1024 / 1024 / 1024)) GiB download)"
+  plan "modules (both editors): ${MODULES} (--cm)"
+  plan "estimated disk required: ${REQUIRED_DISK_GIB} GiB"
+  exit 0
+fi
+
+avail_kib="$(df -Pk "$HOME" | awk 'NR==2 {print $4}')"
+avail_gib=$((avail_kib / 1024 / 1024))
+if [ "$avail_gib" -lt "$REQUIRED_DISK_GIB" ]
+then
+  echo "Error: --unity needs ~${REQUIRED_DISK_GIB} GiB free at ${HOME}, but only ${avail_gib} GiB is available." >&2
+  exit 1
+fi
+
+log "installing general-games Editor ${general_version}..."
+# shellcheck disable=SC2086
+unity install "$GENERAL_SELECTOR" --non-interactive --yes --accept-eula -m $MODULES --cm
+
+log "installing VRChat Editor ${vrchat_version}..."
+# shellcheck disable=SC2086
+unity install "$VRCHAT_VERSION" -c "$VRCHAT_CHANGESET" --non-interactive --yes --accept-eula -m $MODULES --cm
+
+log "done."

--- a/lib/unity-editors.sh
+++ b/lib/unity-editors.sh
@@ -8,10 +8,19 @@ cd "$(cd "$(dirname "$0")"; pwd)/.."
 log() { printf '[unity] %s\n' "$*"; }
 plan() { printf '[unity:plan] %s\n' "$*"; }
 
+# Falls back to the vendor installer's default xdg-layout location: the
+# CLI may already be installed there from an earlier run whose PATH edit
+# (to ~/.bashrc) only reaches future shells, not this one.
 if ! command -v unity >/dev/null 2>&1
 then
-  echo "Error: the unity CLI is not on PATH. Run ./setup once (without --dry-run) first so lib/unity.sh installs it." >&2
-  exit 1
+  if [ -x "${HOME}/.local/bin/unity" ]
+  then
+    PATH="${HOME}/.local/bin:${PATH}"
+    export PATH
+  else
+    echo "Error: the unity CLI is not on PATH. Run ./setup once (without --dry-run) first so lib/unity.sh installs it." >&2
+    exit 1
+  fi
 fi
 
 DRY_RUN=0
@@ -123,11 +132,22 @@ then
   exit 0
 fi
 
-avail_kib="$(df -Pk "$HOME" | awk 'NR==2 {print $4}')"
+# Check space on the CLI's actual configured Editor install path, not
+# assumed to be under $HOME: `unity install-path --set` can point it
+# elsewhere. Walk up to the nearest existing ancestor first, since the
+# target directory itself may not exist yet on a first install and df
+# requires a real path.
+disk_check_path="$(unity install-path)"
+while [ ! -d "$disk_check_path" ]
+do
+  disk_check_path="$(dirname "$disk_check_path")"
+done
+
+avail_kib="$(df -Pk "$disk_check_path" | awk 'NR==2 {print $4}')"
 avail_gib=$((avail_kib / 1024 / 1024))
 if [ "$avail_gib" -lt "$REQUIRED_DISK_GIB" ]
 then
-  echo "Error: --unity needs ~${REQUIRED_DISK_GIB} GiB free at ${HOME}, but only ${avail_gib} GiB is available." >&2
+  echo "Error: --unity needs ~${REQUIRED_DISK_GIB} GiB free at ${disk_check_path}, but only ${avail_gib} GiB is available." >&2
   exit 1
 fi
 

--- a/setup
+++ b/setup
@@ -24,6 +24,7 @@ then
 fi
 
 USE_DESKTOP=0
+USE_UNITY=0
 
 # Normalize the dry-run flag/env to 0|1 up front so a value such as "true"
 # from the environment cannot abort the script on a numeric test under set -e.
@@ -37,7 +38,7 @@ case "${DESKTOP_SUNSHINE_WSL:-0}" in
 esac
 
 usage() {
-  echo "Usage: $0 [-v] [--desktop] [--dry-run] [--desktop-sunshine-wsl]" >&2
+  echo "Usage: $0 [-v] [--desktop] [--unity] [--dry-run] [--desktop-sunshine-wsl]" >&2
 }
 
 # POSIX getopts cannot parse long options, so parse arguments manually while
@@ -47,6 +48,7 @@ do
   case "$1" in
     -v) USE_VIRTUAL=1 ;;
     --desktop) USE_DESKTOP=1 ;;
+    --unity) USE_UNITY=1 ;;
     --dry-run) DESKTOP_DRY_RUN=1 ;;
     --desktop-sunshine-wsl) USE_DESKTOP=1; DESKTOP_SUNSHINE_WSL=1 ;;
     -h|--help) usage; exit 0 ;;
@@ -66,24 +68,40 @@ fi
 export DESKTOP_DRY_RUN
 export DESKTOP_SUNSHINE_WSL
 
-# A dry run targets the desktop layer and implies it, so it works via the
-# --dry-run flag or the DESKTOP_DRY_RUN env var on its own. It is non-mutating:
-# handle it before any install step and before the VM path so it prints a plan
-# and exits without side effects.
+# A dry run targets the desktop and/or Unity Editor layers and implies
+# itself via the --dry-run flag or the DESKTOP_DRY_RUN env var on its own.
+# It is non-mutating: handle it before any install step and before the VM
+# path so it prints a plan and exits without side effects. Bare --dry-run
+# (neither --desktop nor --unity) keeps previewing the desktop layer only,
+# matching prior behavior.
 if [ "$DESKTOP_DRY_RUN" -eq 1 ]
 then
-  lib/desktop.sh
+  if [ "$USE_UNITY" -eq 1 ]
+  then
+    lib/unity-editors.sh --dry-run
+  fi
+  if [ "$USE_DESKTOP" -eq 1 ] || [ "$USE_UNITY" -eq 0 ]
+  then
+    lib/desktop.sh
+  fi
   exit 0
 fi
 
-# --desktop applies only to a real Ubuntu install. The VM/non-Ubuntu path
-# launches a VM and cannot forward the desktop request, so reject the
+# --desktop and --unity apply only to a real Ubuntu install. The VM/non-Ubuntu
+# path launches a VM and cannot forward either request, so reject the
 # combination explicitly rather than silently running the base setup. Desktop
-# support inside the VM is a separate concern handled by sibling issues. The
-# non-mutating "--desktop --dry-run" preview already ran above and is exempt.
+# and Unity Editor support inside the VM are separate concerns handled by
+# sibling issues. The non-mutating "--dry-run" preview already ran above and
+# is exempt.
 if [ "$USE_DESKTOP" -eq 1 ] && [ "$USE_VIRTUAL" -eq 1 ]
 then
   echo "Error: --desktop is not supported with the VM/non-Ubuntu path; run on a real Ubuntu host, or use --desktop --dry-run to preview the plan." >&2
+  exit 1
+fi
+
+if [ "$USE_UNITY" -eq 1 ] && [ "$USE_VIRTUAL" -eq 1 ]
+then
+  echo "Error: --unity is not supported with the VM/non-Ubuntu path; run on a real Ubuntu host, or use --unity --dry-run to preview the plan." >&2
   exit 1
 fi
 
@@ -140,8 +158,19 @@ run_stage lib/mise.sh
 run_stage lib/docker.sh
 run_stage lib/ngrok.sh
 run_stage lib/unity.sh
+# lib/unity.sh installs the CLI to ~/.local/bin as a separate process, so
+# the vendor installer's own PATH edit (to ~/.bashrc, read by future
+# shells) never reaches this already-running script. Add it here so
+# lib/unity-editors.sh can find `unity` within this same setup run.
+PATH="${HOME}/.local/bin:${PATH}"
+export PATH
 run_stage lib/teardown.sh
 run_stage lib/locale.sh
+
+if [ "$USE_UNITY" -eq 1 ]
+then
+  lib/unity-editors.sh
+fi
 
 if [ "$USE_DESKTOP" -eq 1 ]
 then

--- a/tests/setup-cli.test.sh
+++ b/tests/setup-cli.test.sh
@@ -55,6 +55,7 @@ check "--dry-run" 0 "[desktop:plan]" ./setup --dry-run
 check "DESKTOP_DRY_RUN=true env var" 0 "[desktop:plan]" env DESKTOP_DRY_RUN=true ./setup
 check "--desktop -v rejected on the VM path" 1 "not supported" ./setup --desktop -v
 check "--desktop -v --dry-run is exempt" 0 "[desktop:plan]" ./setup --desktop -v --dry-run
+check "--unity -v rejected on the VM path" 1 "not supported" ./setup --unity -v
 
 if [ "${FAILURES}" -gt 0 ]
 then


### PR DESCRIPTION
Resolves #59.

## What changed

- `setup`: adds a `--unity` opt-in flag, matching `--desktop`'s existing contract — rejected on the VM/non-Ubuntu path with a named-reason error (exempting `--unity --dry-run`), and calling `lib/unity-editors.sh` on the native path.
- `lib/unity-editors.sh` (new): installs two pinned Unity Editors via the CLI from #58:
  - the **6.3 LTS stream**, selected explicitly as `6.3` — Unity's `lts` alias is ambiguous between the 6000.0 and 6000.3 lines and can resolve to whichever was patched most recently.
  - **`2022.3.22f1`** (changeset `887be4894c44`), the exact build VRChat's SDK targets.
  - Both install the `android`, `linux-il2cpp`, and `windows-mono` modules with child modules (`--cm`).
  - `--dry-run` resolves both versions and the module set via `unity install --dry-run --json` and prints an estimated disk requirement, exiting without installing anything.
  - A free-disk preflight (a single documented `REQUIRED_DISK_GIB=30` constant, matching the issue's own ~27 GiB measurement) runs before any real download and rejects insufficient space, naming both required and available space.
  - The general-games resolution fails loudly if it resolves outside the `6000.3.*` stream.
  - Nothing here requires `sudo` or an interactive prompt.
- `.cspell.config.yml`: adds `vrchat` to the vocabulary list.

## A bug caught by self-review, fixed before opening this PR

`lib/unity.sh` installs the CLI to `~/.local/bin` as a separate process. The vendor installer's own PATH edit only reaches *future* shells via `~/.bashrc` — it can't and doesn't update the PATH of the already-running `setup` script that invoked it. Without a fix, a single `./setup --unity` on a host that had never installed the CLI before would run `lib/unity.sh` successfully, then immediately fail the very next step because `unity` wasn't on `PATH` within that same script run. `setup` now exports `~/.local/bin` onto `PATH` right after `run_stage lib/unity.sh`. Verified empirically in Docker: a single-process repro without the fix failed exactly as described; with the fix, the same single invocation correctly reaches the Editor-resolution and disk-preflight logic.

## Not implemented here

The issue's "Proposed change" section mentions installing the apt packages Unity's Editor needs to launch on a clean Ubuntu — this is **not** in the issue's actual checkable acceptance-criteria list, and Unity's own official documentation doesn't publish a package list for this. Guessing one from third-party blog sources risked hardcoding package names that don't exist on this repo's target Ubuntu release (some commonly-cited packages, like `libgconf-2-4`, are long removed from current Ubuntu). Left undone rather than guessed; the GUI/X11 stack is otherwise the `--desktop` layer's established concern in this repo.

## Verification

- `shellcheck setup nuke lib/*.sh tests/setup-cli.test.sh`, `npx -y markdownlint-cli2 "**/*.md"`, and `npx -y cspell lint "**" --no-progress` all pass.
- The #56 CLI smoke test (`tests/setup-cli.test.sh`) still passes unchanged.
- Every "verifiable without downloading 13 GiB" acceptance criterion was exercised empirically against the **real** Unity CLI and its live release API in an isolated Docker container (not simulated): the VM-path rejection and its exact error message; the dry-run plan, including the live-resolved `6000.3.21f1` and `2022.3.22f1` versions; the disk preflight correctly rejecting an artificially inflated threshold before any real download began (confirmed no `unity install` real-mode call ran); and non-interactive operation confirmed with stdin closed and no controlling TTY.
- Full-install confirmation (`unity editors -i`, an Editor actually starting) is explicitly operator-side per the issue and was not attempted — it needs ~13 GiB of downloads this sandbox doesn't need to spend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for installing Unity Editors through the setup process.
  - Supports the general-games Unity 6.3 build and the pinned VRChat Unity version.
  - Installs shared Android, Linux IL2CPP, and Windows Mono modules.
  - Added dry-run mode to preview Unity and desktop installation steps.
  - Added validation for Unity CLI availability, installation paths, resolved versions, and disk space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->