### PR TITLE
feat: pin the helper-runtime package spec and bump iddVersion to 0.6.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,7 +34,7 @@
       "Bash(gh search*)",
       "Bash(gh repo view*)",
       "Bash(gh auth status)",
-      "Bash(npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d idd-*)"
+      "Bash(npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/abd841ac0712dec83231ca77096abea67a3497b4 idd-*)"
     ],
     "deny": [
       "Bash(git push --force*)",

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.4.0",
+  "iddVersion": "0.6.0",
   "markerPrefix": "setup-ubuntu",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",
@@ -20,7 +20,8 @@
     "post-fix-validate": "npx -y markdownlint-cli2 --fix \"**/*.md\" && npx -y markdownlint-cli2 \"**/*.md\" && npx -y cspell lint \"**\" --no-progress"
   },
   "helperRuntime": {
-    "profile": "ephemeral-npx"
+    "profile": "ephemeral-npx",
+    "packageSpec": "https://codeload.github.com/kurone-kito/idd-skill/tar.gz/abd841ac0712dec83231ca77096abea67a3497b4"
   },
   "advisoryBotLogins": [
     "copilot-pull-request-reviewer[bot]",


### PR DESCRIPTION
## Summary

Pins the `ephemeral-npx` helper runtime to a specific commit and bumps
`iddVersion` to `0.6.0`, one of roadmap #92's disjoint,
independently-mergeable tracks.

- `.github/idd/config.json`: `iddVersion` `0.4.0` → `0.6.0`; adds
  `helperRuntime.packageSpec` pointing at
  `abd841ac0712dec83231ca77096abea67a3497b4`. Without this field, the
  `ephemeral-npx` runtime resolved helper CLIs from the **mutable**
  `refs/heads/main` archive at run time instead of any pinned commit —
  the exact drift `post-merge-cleanup.yml`'s upstream header comment
  warns about.
- `.claude/settings.json`: updates the SHA embedded in the `npx
  --package` Bash allowlist entry to the same commit, so the
  permission string and the actual helper-resolution behavior agree
  again (they were already inconsistent with each other before this
  change, both stale against the current pin).

No other keys/characters in either file changed; verified via a
normalized diff against `main` with the touched fields stripped.

## Verification

- `idd-doctor` (pinned `abd841ac` package): `.github/idd/config.json
  validates against policy.schema.json` — PASS, no config-schema
  error.
- `npx -y markdownlint-cli2 "**/*.md"`: 0 issues (no markdown files
  touched by this change).
- `npx -y cspell lint "**" --no-progress`: 0 issues.

Closes #88


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal tooling configuration to use the latest approved helper runtime.
  * Updated the internal schema configuration to improve compatibility with current development workflows.
  * No changes to user-facing functionality or exported product behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->