### PR TITLE
chore: bump the pinned idd-skill SHA embedded in idd-doctor.yml to abd841ac

### DIFF
--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Run idd-doctor
         run: >-
           npx --yes --package
-          https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d
+          https://codeload.github.com/kurone-kito/idd-skill/tar.gz/abd841ac0712dec83231ca77096abea67a3497b4
           idd-doctor


### PR DESCRIPTION
## Summary

Bumps the pinned `idd-skill` commit SHA embedded in
`.github/workflows/idd-doctor.yml`'s `npx --package` invocation from
`4e8c7043edcb00dd8447dee83e7a17e5b2604d5d` to
`abd841ac0712dec83231ca77096abea67a3497b4` — one of roadmap #92's
disjoint, independently-mergeable tracks, filed as a follow-up during
#87's B2 planning (see #93 for the full background).

`docs/idd-policy.md` documents that this SHA must stay in sync across
five locations on every template resync; roadmap #92's original five
tracks left this one location unmoved. No other line in the file
changes.

## Why this matters now

PR #95 (#88) discovered the concrete cost of leaving this stale: with
`idd-doctor.yml` still pinned to the pre-resync commit, its bundled
`policy.schema.json` declares `helperRuntime` with
`additionalProperties: false` and does not know `#88`'s new
`packageSpec` field, so CI fails with `$.helperRuntime: additional
property "packageSpec" not allowed`. This PR unblocks #88 — see the
correction posted on roadmap #92's Sequencing section.

## Verification

- `actionlint .github/workflows/idd-doctor.yml`: exit 0.
- `idd-doctor` run locally via the pinned `abd841ac` package against
  this branch (pre-#88 config.json): `result: passed`.
- `npx -y markdownlint-cli2 "**/*.md"`, `npx -y cspell lint "**"
  --no-progress`: both 0 issues.
- This PR's own `idd-doctor` CI check is a live smoke test of the new
  pin (issue #93's acceptance criterion #2).

Closes #93
