### PR TITLE
chore: resync the issue-authoring skill bundle and drop openai.yaml

### DIFF
--- a/.claude/skills/issue-authoring/SKILL.md
+++ b/.claude/skills/issue-authoring/SKILL.md
@@ -76,8 +76,12 @@ needs-decision, blocked-by-human, and out-of-scope.
    in the bundled contract, including the manual fallback for
    `instructions-only` installs with no helper runtime. Resolve every
    reported failure before treating the issue as ready.
-7. When the user explicitly authorizes publication, manage the authoring
-   label for each created or updated issue:
+7. Publish each `ready` drafted body directly under the authoring hold
+   once it passes the mechanical gate (step 6) and the critique pass
+   (the Intake and Clarification phase above) — no separate publish
+   approval is needed. Only skip publishing when the current request
+   explicitly asked for a preview instead. Manage the authoring label
+   for each created or updated issue:
    - resolve `issueAuthoring.authoringLabelName`, defaulting to
      `status:authoring`
    - create the label with `gh label create` before first use when the
@@ -90,27 +94,35 @@ needs-decision, blocked-by-human, and out-of-scope.
      before stopping; deletion needs admin permission the authoring
      agent typically lacks (and `docs/permissions.md` forbids for normal
      IDD), so it is not the default path
-   - remove the label from all published issues only after the full set is
-     published, the user confirms the result, and the user explicitly
-     requests release from the authoring hold for IDD execution
-   - leave the label in place if publishing is interrupted before release
-8. Stop at the approval boundary. Drafting issues does not authorize
-   publishing them or starting the IDD execution loop unless the user
-   explicitly asked for that.
+   - held issues under the label ARE the drafts: do in-place body
+     edits, roadmap relationship wiring, and re-lint of already-published
+     bodies on the published issue itself, under the same label
+   - if a session is interrupted before the set is fully wired, leave
+     the label in place — it alone keeps Discover from selecting the
+     unfinished set until a later session finishes the work
+   - remove the label from all published issues only after the release
+     checklist passes (every child referenced from its roadmap's
+     `## Tracks` list, no unsubstituted placeholders, linter green on
+     every published body) and the user explicitly requests release
+     from the authoring hold
+8. Stop at the single approval boundary: release. Publishing under the
+   hold does not by itself authorize starting the IDD execution loop —
+   only the user's explicit release request does.
 
 ## Reference Routing
 
 - For the bundled contract, output schemas, and discoverability guard:
   read [references/contract.md](references/contract.md).
-- For the bundled boundary between pre-approval drafting and the IDD
-  execution loop: read
+- For the bundled two-stage authoring/release contract and the
+  boundary with the IDD execution loop: read
   [references/workflow-boundary.md](references/workflow-boundary.md).
 - For concrete drafting patterns and example prompts: read
   [references/draft-patterns.md](references/draft-patterns.md).
 - When editing this bundle inside the source repository, keep the
-  bundled references synchronized with the canonical maintenance docs in
-  [../../docs/issue-authoring-skill.md](../../docs/issue-authoring-skill.md)
-  and [../../../docs/idd-workflow.md](../../../docs/idd-workflow.md).
+  bundled references synchronized with the canonical maintenance docs at
+  repo-root `docs/issue-authoring-skill.md` and `docs/idd-workflow.md`
+  (relative links are avoided here since this file is mirrored at a
+  different path depth in `.claude/skills/issue-authoring/`).
 
 ## Output Checklist
 

--- a/.claude/skills/issue-authoring/agents/openai.yaml
+++ b/.claude/skills/issue-authoring/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Issue Authoring"
-  short_description: "Draft IDD-ready issues and roadmaps"
-  default_prompt: "Use $issue-authoring to draft an IDD-ready issue set for this request."

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -841,7 +841,41 @@ Binding rules:
 Backfill is opportunistic and follows the same claim-state precondition
 as the suitability footer.
 
+## Authoring hold and release
+
+Issue authoring uses a two-stage contract: drafting and publishing
+happen together under an authoring hold; release from that hold is the
+only approval boundary.
+
+- **Stage 1 — author-and-publish.** Once a drafted `ready` body passes
+  the mechanical `audit-authored-issue` gate (see
+  [Mechanical pre-publish gate](#mechanical-pre-publish-gate)) and the
+  critique pass, publish it directly under the configured authoring
+  label (`issueAuthoring.authoringLabelName`, defaulting to
+  `status:authoring`) — no separate user approval of the drafted body
+  is required. The label doubles as the draft marker for the held
+  issue and the claim-suppression lock that keeps Discover from
+  selecting it: held issues ARE the drafts, so in-place edits, roadmap
+  relationship wiring, and re-lint of already-published bodies all
+  happen under that same lock. If a session is interrupted before the
+  set is fully wired, leave the label in place — that alone keeps
+  Discover from selecting the unfinished set until a later session
+  finishes the work.
+- **Stage 2 — release.** Before removing the authoring label, run a
+  release checklist: every child issue is referenced from its parent
+  roadmap's `## Tracks` list; no unsubstituted placeholder remains in
+  any published body; the `audit-authored-issue` linter (or its manual
+  fallback) is green on every published body in the set. Remove the
+  label only after that checklist passes and the user explicitly
+  requests release from the authoring hold. Release is a human action;
+  nothing in this bundle auto-releases a held issue set.
+
 ## Publication boundary
 
-Drafting issues does not authorize publishing them or starting the IDD
-execution loop unless the user explicitly asked for that next step.
+Publishing a drafted `ready` body under the authoring hold does not
+need a separate user approval once it passes the mechanical
+`audit-authored-issue` gate and the critique pass — see
+[Authoring hold and release](#authoring-hold-and-release) above for the
+full two-stage contract. Removing the authoring label and starting the
+IDD execution loop both require the user's explicit hold-release
+request; nothing else authorizes either.

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -16,10 +16,12 @@ chooser for output shapes.
 ## Output chooser
 
 Draft an orphan issue only when one autonomous task can finish the work
-and the target repository is discoverable through `issue-scope:
-orphan-first`. If the repository uses `orphan-first-policy:
+and the target repository discovers orphans (`issue-scope:
+roadmap-first`, the default, via the orphan fallback, or
+`orphan-first`). If the repository uses `orphan-first-policy:
 maintainer-approved`, include a post-publication approval step after the
-final issue content is stable. If a public repository uses
+final issue content is stable. If the repository sets `issue-scope:
+roadmap` (roadmap-only) or a public repository uses
 `orphan-first-policy: public-disabled`, draft a roadmap package instead.
 
 If the repository keeps the broader secure-by-default issue-author
@@ -588,9 +590,15 @@ verification shape, not a rigid edit order.
 
 ## Publication boundary
 
-If the user asked for drafts only, stop after reporting the issue set,
-assumptions, and non-ready buckets.
+Publish each `ready` body directly under the authoring hold once it
+passes the mechanical gate and the critique pass — this is the default
+outcome of drafting, and it needs no separate publish approval. Stop
+after publishing (and applying/creating the authoring label) unless
+the user also separately requests release from the authoring hold —
+release is what authorizes starting the IDD execution loop, so a
+request phrased as "start the IDD execution loop" counts as that same
+release request, not a separate path around it.
 
-If the user explicitly asked to publish issues, create or update them
-and then stop unless they also separately asked to start the IDD
-execution loop.
+If the user asked for drafts only (a preview before anything is
+created), honor that instead: stop after reporting the issue set,
+assumptions, and non-ready buckets, without publishing.

--- a/.claude/skills/issue-authoring/references/workflow-boundary.md
+++ b/.claude/skills/issue-authoring/references/workflow-boundary.md
@@ -1,23 +1,27 @@
 # Workflow Boundary
 
-This bundle handles pre-approval issue drafting only.
+This bundle handles issue authoring end to end under the authoring
+hold: drafting and publishing are one continuous stage with no
+per-step approval, and release from the authoring hold is the single
+approval boundary that hands off to IDD execution.
 
-## Handoff sequence
+## Two-stage contract
 
-The issue-authoring bundle fits into a three-phase handoff:
+### Stage 1: Author-and-publish (under the hold)
 
-### Phase 1: Drafting (this bundle)
-
-- Skill drafts issues in the target repository
-- Issues move through readiness buckets: `deferred` → `ready` or
-  → escalation bucket (`needs-decision`, `blocked-by-human`, `out-of-scope`)
-- User approves the issue set before any publication
-
-### Phase 2: Publishing (user-authorized handoff)
-
-- User explicitly asks for publication
-- Bundled skill resolves the authoring label from
-  `issueAuthoring.authoringLabelName`, defaulting to `status:authoring`
+- Skill drafts issues in the target repository. Each candidate moves
+  through the readiness buckets: `deferred` → `ready` or an escalation
+  bucket (`needs-decision`, `blocked-by-human`, `out-of-scope`)
+- Before publishing a `ready` body, bundled skill runs the mechanical
+  `audit-authored-issue` gate and the critique pass (both unchanged
+  and still mandatory)
+- Bundled skill then publishes directly under the configured authoring
+  label (`issueAuthoring.authoringLabelName`, defaulting to
+  `status:authoring`) — **no prior user approval of the drafted body
+  is required**. If the current request asked only for a preview
+  (drafts to look at before anything is created), bundled skill stops
+  after reporting the proposed set instead of publishing; publishing
+  is otherwise the default outcome of drafting, not an opt-in step
 - If the label does not exist in the target repository, bundled skill
   creates it with `gh label create` before first use; label creation or
   application failure blocks publishing
@@ -30,31 +34,36 @@ The issue-authoring bundle fits into a three-phase handoff:
   issue before stopping; deletion needs admin permission the authoring
   agent typically lacks (and `docs/permissions.md` forbids for normal IDD),
   so it is not the default path
-- User verifies the published issues look correct
-- Bundled skill removes the authoring label from all published issues only
-  after the full issue set is published, the user confirms the result, and
-  the user explicitly requests release from the authoring hold for IDD
-  execution
-- If publishing is interrupted before release, the authoring label remains
-  in place as the IDD discover guard signal
-- Published issues remain on hold until user explicitly requests IDD execution
+- **The held issue IS the draft.** In-place body edits, roadmap
+  relationship wiring (children first, then roadmaps once the real
+  issue numbers exist), and re-lint of already-published bodies all
+  happen on the published issue, under the same label — not in a
+  session-local buffer that a later session cannot see
+- **Interrupted-session guard.** If a Stage 1 session stops before the
+  set is fully wired and stable, the authoring label stays on every
+  issue it already published. The label alone is what keeps Discover
+  from selecting an unfinished set, so a later session (or the same
+  session, resumed) can find and finish the work with no extra
+  bookkeeping
 
-### Phase 3: Execution (separate IDD loop)
+### Stage 2: Release (the single approval boundary)
 
-- User explicitly asks to start the IDD execution loop
-- Target repository's `.github/instructions/idd-discover.instructions.md`
-  takes over
-- IDD discover phase runs A0-T/A0-O/A1-A4.5 gates
-- Suitable issues are claimed, worked, and merged
-
-**Approval boundaries**:
-
-- **After drafting** (Phase 1 → Phase 2): User must explicitly approve the
-  issue set
-- **After publishing** (Phase 2 → Phase 3): User must explicitly request IDD
-  execution
-- **No implicit progression**: Each handoff requires explicit user request.
-  The bundle must not auto-transition to publishing or execution.
+- The user's explicit hold-release request is the only approval this
+  bundle's workflow requires, and it authorizes IDD execution for the
+  released issues
+- Before removing the authoring label, bundled skill runs a release
+  checklist that absorbs the rigor of the dropped middle step:
+  - every child issue is referenced from its parent roadmap's
+    `## Tracks` list
+  - no unsubstituted placeholder (a leftover `#TBD`, template
+    stand-in, or similar) remains in any published body
+  - the `audit-authored-issue` linter (or its manual fallback under
+    `instructions-only`) is green on every published body in the set
+- Bundled skill removes the authoring label from all published issues
+  only after the release checklist passes and the user's release
+  request is explicit
+- Release remains a human action; nothing in this bundle auto-releases
+  a held issue set
 
 ## A4.5 Gate Timing
 
@@ -99,11 +108,16 @@ time and report the specific failure (unclear, invalid, duplicate).
 - start the Discover -> Claim -> Work loop implicitly
 - treat bundled references as a replacement for repository execution
   instructions
-- publish issues unless the user explicitly asked for publishing
+- publish a body that has not passed the mechanical
+  `audit-authored-issue` gate and the critique pass
+- remove the authoring label from any issue without an explicit
+  release request
 
 ## Handoff to execution
 
-After the user approves the issue set, wait for a separate request to
-publish the issues or start the IDD execution loop. Only then should
-the workflow hand off to the repository's normal entry file and routed
-`.github/instructions/*.instructions.md` phase files.
+Once the user's explicit release request removes the authoring label
+from every issue in the released set, execution is authorized: the
+repository's normal entry file and routed
+`.github/instructions/*.instructions.md` phase files (Discover, Claim,
+Work) may pick up the released issues. This bundle does not itself
+start that loop.


### PR DESCRIPTION
## Summary

Resyncs this repository's `.claude/skills/issue-authoring/` bundle from
upstream's `skills/issue-authoring/` source at
`abd841ac0712dec83231ca77096abea67a3497b4` — one of roadmap #92's
disjoint, independently-mergeable tracks.

- Overwrites `SKILL.md`, `references/contract.md`,
  `references/draft-patterns.md`, and `references/workflow-boundary.md`
  with their upstream counterparts, verbatim.
- Deletes `agents/openai.yaml` (upstream removed it in 0.5.0 — no
  repository doc named a consumer runtime for its `$issue-authoring`
  macro syntax, and it went untouched since the skill's scaffold
  commit) and the now-empty `agents/` directory.
- Installed path stays `.claude/skills/issue-authoring/`, unchanged
  from its #44 relocation off the upstream source-layout path.

## Verification

- SHA-256 hash comparison of all 4 local files against upstream raw
  content: identical.
- `.claude/skills/issue-authoring/agents/` confirmed removed, not left
  empty on disk.
- `SKILL.md` frontmatter still valid (`name: issue-authoring`,
  `description:` present) — Claude Code continues to discover it as an
  available skill.
- `npx -y markdownlint-cli2 "**/*.md"`, `npx -y cspell lint "**"
  --no-progress`: both 0 issues.

Closes #89
