### PR TITLE
chore: merge the upstream markdownlint-cli2 ignore pattern

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,3 +1,4 @@
 ignores:
   - .github/CODE_OF_CONDUCT*
   - .terraform/**/*
+  - node_modules/**/*.md


### PR DESCRIPTION
## Summary

Merges the upstream `idd-skill` template's new `.markdownlint-cli2.yaml`
ignore pattern into this repository's own config — one of roadmap #92's
disjoint, independently-mergeable tracks.

Upstream added `idd-template/.markdownlint-cli2.yaml` at
`abd841ac0712dec83231ca77096abea67a3497b4` with an `ignores` list that
includes `node_modules/**/*.md`. This repository's existing
`.markdownlint-cli2.yaml` predates that template file and already
ignores `.github/CODE_OF_CONDUCT*` plus its own `.terraform/**/*`
pattern, so the only genuinely new pattern to merge in is
`node_modules/**/*.md`. Appends it without touching or reordering the
two existing entries, per `idd-template/ONBOARDING.md`'s guidance for
merging rule overrides by hand when a target repository already owns
this file.

## Verification

- `.markdownlint-cli2.yaml`'s `ignores` list now contains all three
  entries.
- `.markdownlint.yml` unchanged (byte-identical to `main`).
- `npx -y markdownlint-cli2 "**/*.md"`, `npx -y cspell lint "**"
  --no-progress`: both 0 issues; the `Finding:` line confirms the new
  glob is active.

Closes #90
