### PR TITLE
fix: trust rulesets-only branch protection in the IDD CI gate

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -31,6 +31,9 @@
   "advisoryWait": {
     "convergenceScope": "idd-claimed"
   },
+  "ciGate": {
+    "trustEmptyProtectionReads": true
+  },
   "worktreeGuard": {
     "enabled": true
   },


### PR DESCRIPTION
## Summary

Records this repository's rulesets-only branch-protection policy so the
IDD CI gate stops failing closed on `main`.

`main` is now protected by GitHub Rulesets, not the legacy classic
branch-protection API, so `branches/main/protection` genuinely returns
`404`. Per the IDD CI gate's documented 404-vs-403 ambiguity rule, an
untrusted `404` on that read is treated exactly like a `403`
(unreadable) by default — which made `idd-pre-merge-readiness` fail
closed on PR #98 with `cannot determine required checks:
protection/ruleset unreadable`, reproduced twice non-transiently.

Sets `"ciGate": {"trustEmptyProtectionReads": true}` in
`.github/idd/config.json`, the documented opt-out for exactly this
case — a git-committed, human-authorized policy decision. No live
GitHub ruleset or branch-protection setting is touched.

## Verification

- `.github/idd/config.json` passes `idd-doctor`'s
  `.github/idd/config.json validates against policy.schema.json` check.
- JSON is syntactically valid; no other key was changed.

Closes #99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration safeguards to allow trusted empty protection reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->