### PR TITLE
docs: record the idd-skill 0.6.0 resync in docs/idd-policy.md

### DIFF
--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -210,9 +210,10 @@ on every upstream bump. `ephemeral-npx` avoids both costs.
   resync, the four above plus this workflow file. This workflow is
   **hosted but not registered as a required check**: two GitHub
   Rulesets exist on this repository today (`gh api
-  repos/{owner}/{repo}/rulesets` returns `main` and `features`, both
-  `enforcement: active`) — a maintainer-created addition, not one this
-  IDD loop configured. Each enables `copilot_code_review`
+  repos/{owner}/{repo}/rulesets` includes rulesets named `main` and
+  `features`, both `enforcement: active`) — a maintainer-created
+  addition, not one this IDD loop configured. Each enables
+  `copilot_code_review`
   (`review_on_push: true`), so Copilot now reviews every push
   automatically; `main` (targeting `~DEFAULT_BRANCH`) also enables the
   `deletion` / `non_fast_forward` rules and a `pull_request` rule with

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -27,8 +27,7 @@ changes.
   apart. `.markdownlint-cli2.yaml` required a hand merge (this
   repository's file predates upstream's own copy) rather than a straight
   overwrite. Registering `idd-advisory-convergence` as a required status
-  check was reconsidered and declined again, matching the 0.4.0 entry's
-  original reasoning.
+  check was reconsidered and declined again.
 
 ## Project values
 

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -16,6 +16,19 @@ changes.
   (2026-07-24). `.github/instructions/lite/` is deliberately excluded —
   it targets the lightweight local-model tier this repository does not
   use.
+- Resynced: `iddVersion 0.6.0`, imported from
+  [`kurone-kito/idd-skill`](https://github.com/kurone-kito/idd-skill)
+  `main` at commit
+  [`abd841ac0712dec83231ca77096abea67a3497b4`](https://github.com/kurone-kito/idd-skill/commit/abd841ac0712dec83231ca77096abea67a3497b4)
+  (2026-08-12). `.github/instructions/lite/` remains deliberately
+  excluded, unchanged reasoning from the 0.4.0 entry.
+  `helperRuntime.packageSpec` is now pinned to the same commit so the
+  `ephemeral-npx` runtime and the distributed instructions never drift
+  apart. `.markdownlint-cli2.yaml` required a hand merge (this
+  repository's file predates upstream's own copy) rather than a straight
+  overwrite. Registering `idd-advisory-convergence` as a required status
+  check was reconsidered and declined again, matching the 0.4.0 entry's
+  original reasoning.
 
 ## Project values
 
@@ -144,10 +157,11 @@ add files to this shell-and-Terraform repository and need re-vendoring
 on every upstream bump. `ephemeral-npx` avoids both costs.
 
 - Pinned helper package spec:
-  `https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d`
+  `https://codeload.github.com/kurone-kito/idd-skill/tar.gz/abd841ac0712dec83231ca77096abea67a3497b4`
   — intentionally pinned to the same commit the instruction files were
-  imported from in #41, so a helper's JSON output contract can never
-  drift away from the instruction step that reads it.
+  imported from (originally in #41, resynced to this commit in #88), so
+  a helper's JSON output contract can never drift away from the
+  instruction step that reads it.
 - Canonical invocation form: `npx --yes --package <pinned-spec>
   idd-<helper>`. Under this profile the `idd-*` bin facade is the
   authoritative surface, not `node scripts/*.mjs`.
@@ -194,14 +208,20 @@ on every upstream bump. `ephemeral-npx` avoids both costs.
   `idd-advisory-convergence` invocation from the same pinned spec — the
   commit SHA now has to stay in sync across five locations on a future
   resync, the four above plus this workflow file. This workflow is
-  **hosted but not yet registered as a required check**: no
-  ruleset exists on this repository today (`gh api
-  repos/{owner}/{repo}/rulesets` returns `[]`), so a maintainer who
-  wants to enforce it opens Settings → Rules → Rulesets → New branch
-  ruleset, targets `main`, enables "Require status checks to pass", and
-  adds `idd-advisory-convergence` (the job id) to the required-checks
-  list — this creates the repository's first ruleset rather than
-  editing an existing one.
+  **hosted but not registered as a required check**: two GitHub
+  Rulesets exist on this repository today (`gh api
+  repos/{owner}/{repo}/rulesets` returns `main` and `features`, both
+  `enforcement: active`) — a maintainer-created addition, not one this
+  IDD loop configured. Each enables `copilot_code_review`
+  (`review_on_push: true`), so Copilot now reviews every push
+  automatically; `main` (targeting `~DEFAULT_BRANCH`) also enables the
+  `deletion` / `non_fast_forward` rules and a `pull_request` rule with
+  `required_approving_review_count: 0`. Neither ruleset declares a
+  `required_status_checks` rule, so `idd-advisory-convergence` still is
+  not a GitHub-enforced merge gate — a maintainer who wants to enforce
+  it opens Settings → Rules → Rulesets → edit `main`, enables "Require
+  status checks to pass", and adds `idd-advisory-convergence` (the job
+  id) to the required-checks list.
   `--assert` exits non-zero for any not-ready verdict, including the
   ordinary "Copilot has not reviewed this HEAD yet" pending case —
   GitHub Actions has no distinct non-failing "pending" state, so this
@@ -212,9 +232,13 @@ on every upstream bump. `ephemeral-npx` avoids both costs.
   `ciGate.externalCheckWaivers.mode` is `maintainer-authorized` (not its
   default, `disabled`) and `idd-advisory-convergence` is listed under
   `ciGate.externalChecks.waivable`. **Neither precondition is met
-  today**: `ciGate` is absent from `.github/idd/config.json` entirely,
-  so both default closed. A maintainer who wants the escape hatch has
-  to add both keys explicitly; until then, a stuck not-ready verdict
+  today**: `ciGate` now exists in `.github/idd/config.json` (added by
+  #99 to trust an empty classic branch-protection read, now that this
+  repository's branch protection lives in the rulesets above instead of
+  the classic API), but it sets only `trustEmptyProtectionReads`;
+  `externalCheckWaivers` is still unset, so both default closed. A
+  maintainer who wants the escape hatch has to add both keys
+  explicitly; until then, a stuck not-ready verdict
   past the 24h deadline has no waiver available, only the underlying
   advisory review actually converging. Posting a waiver comment, once
   the escape hatch is enabled, does not by itself re-run the check —


### PR DESCRIPTION
## Summary

Records the idd-skill 0.6.0 resync in `docs/idd-policy.md` — the
finalize track for roadmap #92, blocked on all five sibling tracks
(#86, #87, #88, #89, #90), all now merged.

- Appends the `iddVersion 0.6.0` /
  `abd841ac0712dec83231ca77096abea67a3497b4` (2026-08-12) entry to the
  "Imported template snapshot" section, alongside the existing 0.4.0
  entry.
- Corrects three places where the doc had drifted from
  `.github/idd/config.json` as a side effect of the sibling tracks:
  - The pinned helper package spec still named the pre-resync
    `4e8c7043...` commit; updated to `abd841ac...` (#88).
  - The `idd-advisory-convergence.yml` section still claimed no
    ruleset existed on this repository. Two rulesets ("main",
    "features") now do — created directly by the repository owner
    mid-resync, not by this IDD loop. Describes their actual rules
    and confirms neither registers `idd-advisory-convergence` as a
    required status check.
  - The same section still claimed `ciGate` was entirely absent from
    `config.json`; it now exists with `trustEmptyProtectionReads: true`
    (#99, needed once the rulesets above made the classic
    branch-protection read ambiguous), though `externalCheckWaivers`
    remains unset, so the waiver-escape-path conclusion is unchanged.

## Verification

- Every remaining bullet in `docs/idd-policy.md`'s "Policy decisions"
  and "Project values" sections cross-checked against the current
  `.github/idd/config.json`: no further drift found.
- `npx -y markdownlint-cli2 "**/*.md"`: 0 issues.
- `npx -y cspell lint "**" --no-progress`: 0 issues.

Closes #91


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the IDD policy documentation to align with template version 0.6.0.
  * Clarified advisory-convergence rules, including automatic Copilot reviews and status-check behavior.
  * Documented the current `ciGate` configuration and default handling of external-check waivers.
  * Updated references to the corresponding helper runtime version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->