### PR TITLE
feat: install the apt package Unity Editor needs to launch

### DIFF
--- a/docs/unity.md
+++ b/docs/unity.md
@@ -37,6 +37,14 @@ Two pinned Editors, each with the `android`, `linux-il2cpp`, and
 - **`2022.3.22f1`** (changeset `887be4894c44`) — the exact build VRChat's SDK
   targets.
 
+`lib/unity-editors.sh` also installs one apt package alongside the Editors,
+`libgtk-3-0t64` (`libgtk-3-0` on Ubuntu releases that predate the 64-bit
+`time_t` package rename): the freshly installed Editor binary fails the
+dynamic linker on `libgtk-3.so.0` without it, before ever reaching Unity's
+own license check. Discovered empirically — see the comment above
+`resolve_apt_package` in that script for the reproduction. No other
+package was needed, with or without the `linux-il2cpp` module installed.
+
 ## Version policy
 
 The general-games Editor is selected with the explicit `6.3` selector, not

--- a/lib/unity-editors.sh
+++ b/lib/unity-editors.sh
@@ -161,11 +161,6 @@ then
   exit 0
 fi
 
-unity_apt_package="$(resolve_apt_package libgtk-3-0t64 libgtk-3-0)"
-log "installing Editor runtime dependency (${unity_apt_package})..."
-sudo DEBIAN_FRONTEND=noninteractive apt-get install \
-  --no-install-recommends -y -qq "$unity_apt_package"
-
 # Check space on the CLI's actual configured Editor install path, not
 # assumed to be under $HOME: `unity install-path --set` can point it
 # elsewhere. Walk up to the nearest existing ancestor first, since the
@@ -184,6 +179,13 @@ then
   echo "Error: --unity needs ~${REQUIRED_DISK_GIB} GiB free at ${disk_check_path}, but only ${avail_gib} GiB is available." >&2
   exit 1
 fi
+
+# Runs only after the disk preflight above passes, so a run that fails
+# that check leaves no partial apt-level system change behind.
+unity_apt_package="$(resolve_apt_package libgtk-3-0t64 libgtk-3-0)"
+log "installing Editor runtime dependency (${unity_apt_package})..."
+sudo DEBIAN_FRONTEND=noninteractive apt-get install \
+  --no-install-recommends -y -qq "$unity_apt_package"
 
 # Installs the exact version validated above, not the selector: re-passing
 # the selector here could resolve to a different (newer) release if one

--- a/lib/unity-editors.sh
+++ b/lib/unity-editors.sh
@@ -70,8 +70,12 @@ resolve_apt_package() {
   if apt-cache show "$1" >/dev/null 2>&1
   then
     printf '%s' "$1"
-  else
+  elif apt-cache show "$2" >/dev/null 2>&1
+  then
     printf '%s' "$2"
+  else
+    echo "Error: neither '$1' nor '$2' is a known apt package on this system (stale apt lists, or an unsupported Ubuntu release). Run 'sudo apt-get update' and retry, or file an issue if this release genuinely lacks both." >&2
+    exit 1
   fi
 }
 

--- a/lib/unity-editors.sh
+++ b/lib/unity-editors.sh
@@ -50,6 +50,31 @@ GENERAL_PREFIX="6000.3."
 VRCHAT_VERSION="2022.3.22f1"
 VRCHAT_CHANGESET="887be4894c44"
 
+# Discovered empirically (#85): a freshly installed Editor
+# (`-batchmode -nographics -quit`, no project) on a clean Ubuntu image
+# carrying only the packages `lib/base-install.sh` already installs
+# fails the dynamic linker before reaching Unity's own license check —
+# `error while loading shared libraries: libgtk-3.so.0: cannot open
+# shared object file: No such file or directory`. Installing the
+# package below is the only apt dependency this repeatedly reproduced;
+# once present, the Editor reaches "No valid Unity Editor license
+# found" cleanly (both without any module and with `linux-il2cpp`
+# installed), so no other library is missing.
+#
+# The package providing `libgtk-3.so.0` was renamed for the 64-bit
+# `time_t` transition: `libgtk-3-0t64` on 24.04+, still `libgtk-3-0` on
+# 22.04 and older (no transitional package bridges the two names, so a
+# hardcoded single name breaks one release or the other).
+resolve_apt_package() {
+  # $1 = current (post-t64-rename) name, $2 = pre-rename name
+  if apt-cache show "$1" >/dev/null 2>&1
+  then
+    printf '%s' "$1"
+  else
+    printf '%s' "$2"
+  fi
+}
+
 # `unity install --dry-run --json` output is parsed with grep/sed instead
 # of jq: this script can run before base-install.sh (a bare --unity
 # --dry-run only needs the CLI, already required above), so jq is not
@@ -131,6 +156,11 @@ then
   plan "estimated disk required: ${REQUIRED_DISK_GIB} GiB"
   exit 0
 fi
+
+unity_apt_package="$(resolve_apt_package libgtk-3-0t64 libgtk-3-0)"
+log "installing Editor runtime dependency (${unity_apt_package})..."
+sudo DEBIAN_FRONTEND=noninteractive apt-get install \
+  --no-install-recommends -y -qq "$unity_apt_package"
 
 # Check space on the CLI's actual configured Editor install path, not
 # assumed to be under $HOME: `unity install-path --set` can point it


### PR DESCRIPTION
## Summary

Installs the one apt package a freshly installed Unity Editor needs to
launch far enough to reach its own license/activation check, closing
the gap `./setup --unity` (#59) left open.

- Reproduced empirically in an isolated Ubuntu 24.04 container: a clean
  `6000.3.21f1` Editor install, launched `-batchmode -nographics -quit`
  on a base image carrying only the packages `lib/base-install.sh`
  already installs, fails the dynamic linker on `libgtk-3.so.0` before
  reaching the license check.
- Installing the package that provides it was the only missing
  dependency this reproduced — verified both without any module and
  with `linux-il2cpp` installed; no other library is missing either
  way, and the Editor then reaches "No valid Unity Editor license
  found" cleanly.
- The providing package was renamed for the 64-bit `time_t`
  transition: `libgtk-3-0t64` on Ubuntu 24.04+, still `libgtk-3-0` on
  22.04 and older (confirmed via `apt-cache show`/`apt-cache search`
  against both releases — no transitional package bridges the two
  names). `lib/unity-editors.sh` now resolves the correct name at
  runtime via `apt-cache show`, matching this repository's existing
  `/etc/os-release`-based release-conditional pattern
  (`lib/docker.sh`).
- Wired into `lib/unity-editors.sh`'s `--unity`-only path, after the
  `--dry-run` exit, so `--unity --dry-run` still installs nothing and
  a bare `./setup` (no `--unity`) never installs this package.
- `docs/unity.md`'s "What gets installed" section documents the
  package and points to the reproduction comment in the script.

## Verification

- `shellcheck setup nuke lib/*.sh`: 0 issues.
- `npx -y markdownlint-cli2 "**/*.md" && npx -y cspell lint "**" --no-progress`:
  0 issues (no new vocabulary needed).
- End-to-end reproduction, twice, in disposable Docker containers
  (`ubuntu:24.04` base + this repository's own `cloud-init.yml`
  package list + the Unity CLI, matching `lib/unity.sh`'s exact
  install command):
  1. Before the fix: Editor launch fails with the `libgtk-3.so.0`
     dynamic-linker error.
  2. After the fix (package installed via the new
     `resolve_apt_package` logic exactly as scripted): Editor launch
     reaches `No valid Unity Editor license found` in the log, with
     both zero modules and `linux-il2cpp` installed.
  3. `libgtk-3-0` (the pre-rename name) confirmed present via
     `apt-cache search` on a separate `ubuntu:22.04` container, so the
     fallback branch resolves correctly on that release too.

Closes #85


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unity Editor installations now automatically install the required GTK runtime dependency.
  * Installation supports both newer and older Ubuntu package names.

* **Documentation**
  * Updated Unity installation guidance to describe the GTK dependency and related startup error.
  * Clarified that no additional apt package is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->