### PR TITLE
fix: pin lib/base-install.sh's yq invocation to /usr/bin/yq

### DIFF
--- a/lib/base-install.sh
+++ b/lib/base-install.sh
@@ -11,7 +11,11 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
   --no-install-recommends -y -qq yq
 
-# NOTE: The yq from apt is kislyuk/yq.
-mapfile -t packages < <(yq -r '.packages | sort | .[]' cloud-init.yml)
+# NOTE: The yq from apt is kislyuk/yq. Invoke it by absolute path (not
+# a bare `yq`) so this always resolves to that binary even when a
+# different yq implementation earlier on PATH (for example, one
+# installed by mise) would otherwise shadow it -- the two use
+# incompatible CLI syntax.
+mapfile -t packages < <(/usr/bin/yq -r '.packages | sort | .[]' cloud-init.yml)
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
   --no-install-recommends -y -qq "${packages[@]}"


### PR DESCRIPTION
## Summary

Pin `lib/base-install.sh`'s `cloud-init.yml` packages-list parse to the apt-installed `yq` binary's absolute path (`/usr/bin/yq`) instead of a bare `yq` lookup. Bare `yq` resolves via `$PATH`, which can silently pick up a different `yq` implementation once one lands earlier on `$PATH` -- the two tools use incompatible CLI syntax, so a wrong resolution would break this parse without warning.

Closes #104

## Background

This surfaced while investigating `kurone-kito/dotfiles#257`'s plan to add several CLI tools, including a mikefarah-flavored `yq`, to dotfiles' mise config. Once that lands, a machine with mise active could have a `yq` earlier on `PATH` than `/usr/bin/yq`. `lib/base-install.sh` runs before `lib/mise.sh` in `setup`, so it cannot itself depend on mise being set up yet -- its own `yq` invocation needs to stay unambiguous regardless of what else is on `PATH`.

A related, independent issue (`kurone-kito/setup.ubuntu#105`) tracks opting several other apt packages out in favor of that same dotfiles mise config once it lands; this PR does not depend on it and vice versa -- either can proceed in any order.

## Follow-up

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package-list extraction by consistently using the intended YAML processing tool.
  * Expanded guidance to clarify command-line compatibility and avoid tool-selection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->