### PR TITLE
docs: add OKF frontmatter to local docs/ pages

### DIFF
--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -1,3 +1,10 @@
+---
+type: guide
+title: Optional desktop layer
+description: Walks through enabling the opt-in graphical desktop layer for GUI workloads.
+tags: [desktop, gui]
+---
+
 # Optional desktop layer
 
 The default `./setup` installs a CLI-only environment. An **opt-in**

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: IDD policy decisions
+description: Records this repository's onboarding decisions for the imported IDD workflow.
+tags: [idd-policy, onboarding]
+---
+
 # IDD policy decisions
 
 This project adopts the Issue-Driven Development (IDD) workflow from the

--- a/docs/unity.md
+++ b/docs/unity.md
@@ -1,8 +1,8 @@
 ---
 type: guide
 title: Optional Unity layer
-description: Walks through enabling the opt-in Unity CLI and pinned Editor layer.
-tags: [unity, gui]
+description: Documents the Unity CLI install and the opt-in pinned Editor layer.
+tags: [unity, editor]
 ---
 
 # Optional Unity layer

--- a/docs/unity.md
+++ b/docs/unity.md
@@ -1,3 +1,10 @@
+---
+type: guide
+title: Optional Unity layer
+description: Walks through enabling the opt-in Unity CLI and pinned Editor layer.
+tags: [unity, gui]
+---
+
 # Optional Unity layer
 
 The Unity CLI installs in the default `./setup` path — it needs no `sudo` and


### PR DESCRIPTION
## Summary

Adds the `type`/`title`/`description`/`tags` OKF frontmatter block
(documented in `docs/customization.md`'s "Docs Bundle Frontmatter
Convention (OKF)" section) to the three local-only `docs/` pages that
were still missing it:

- `docs/desktop.md`
- `docs/unity.md`
- `docs/idd-policy.md`

Closes #108

## Background

`docs/customization.md` already documents this convention and states
that new local pages should carry conforming frontmatter, but these
three pages predate that convention and never got it.

## Changes

- `type: guide` for `desktop.md` and `unity.md` (adopter walkthroughs
  for an opt-in layer); `type: reference` for `idd-policy.md` (a
  standing decisions record, same role as `docs/policy-constants.md`)
- `title` matches each page's `# H1` exactly
- `description`: a single verb-first sentence following this bundle's
  existing house style
- `tags`: a small topic-specific list

No other files are touched: `docs/index.md` (generated table), other
`idd-template`-imported `docs/*.md` pages, `.github/instructions/**`,
and `profiles/**` are all unchanged.

## Verification

`npx -y markdownlint-cli2 "**/*.md" && npx -y cspell lint "**" --no-progress` exits 0.
