### PR TITLE
feat: pin the helper-runtime package spec and bump iddVersion to 0.7.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,7 +34,7 @@
       "Bash(gh search*)",
       "Bash(gh repo view*)",
       "Bash(gh auth status)",
-      "Bash(npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/abd841ac0712dec83231ca77096abea67a3497b4 idd-*)"
+      "Bash(npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0 idd-*)"
     ],
     "deny": [
       "Bash(git push --force*)",

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.6.0",
+  "iddVersion": "0.7.0",
   "markerPrefix": "setup-ubuntu",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",
@@ -21,7 +21,7 @@
   },
   "helperRuntime": {
     "profile": "ephemeral-npx",
-    "packageSpec": "https://codeload.github.com/kurone-kito/idd-skill/tar.gz/abd841ac0712dec83231ca77096abea67a3497b4"
+    "packageSpec": "https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0"
   },
   "advisoryBotLogins": [
     "copilot-pull-request-reviewer[bot]",

--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Run idd-doctor
         run: >-
           npx --yes --package
-          https://codeload.github.com/kurone-kito/idd-skill/tar.gz/abd841ac0712dec83231ca77096abea67a3497b4
+          https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0
           idd-doctor


### PR DESCRIPTION
## Summary

Bumps this repository's pinned `idd-skill` helper-runtime commit from
`abd841ac0712dec83231ca77096abea67a3497b4` to
`f51a8bb73a47452eff5799e8a27251b660ba4ae0` (the `iddVersion 0.7.0`
release) across the three local locations that must stay in sync:

- `.github/idd/config.json` — `iddVersion` → `0.7.0`,
  `helperRuntime.packageSpec` → the new SHA
- `.claude/settings.json` — the `Bash(npx --yes --package ... idd-*)`
  allowlist entry
- `.github/workflows/idd-doctor.yml` — the embedded `npx --package`
  invocation

No other key or line in any of these three files changes.

## Closing

Closes #119

## Background

Part of the `idd-template-resync-v0-7-0` roadmap (#122). Moving all
three locations in one change avoids the ordering hazard the prior
resync (#92) discovered mid-flight: #88 (config pin) merged before #93
(`idd-doctor.yml`'s own embedded pin) was even filed, and PR #95's
`idd-doctor` check then failed deterministically against the stale
pre-resync schema.

`docs/idd-policy.md`'s two occurrences of the old SHA are deliberately
out of scope here — deferred to #116's Track 5, which asserts the
final post-resync state across every other roadmap track.
`.github/workflows/idd-advisory-convergence.yml` also still embeds the
old SHA, but that file's full-content resync (including its own pin)
is roadmap track #118's scope, not this issue's.

## Follow-up

None beyond the roadmap's remaining tracks (#117, #118, #120, #121, #116).
