### PR TITLE
chore(idd): drop coderabbit/codex from advisoryBotLogins

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -23,11 +23,7 @@
     "profile": "ephemeral-npx",
     "packageSpec": "https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0"
   },
-  "advisoryBotLogins": [
-    "copilot-pull-request-reviewer[bot]",
-    "coderabbitai[bot]",
-    "chatgpt-codex-connector[bot]"
-  ],
+  "advisoryBotLogins": ["copilot-pull-request-reviewer[bot]"],
   "advisoryWait": {
     "convergenceScope": "idd-claimed"
   },

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -82,8 +82,14 @@ scripts.
   location)
 - Helper runtime profile: `ephemeral-npx` (see
   [Helper runtime](#helper-runtime-ephemeral-npx) below)
-- Advisory bot logins: `copilot-pull-request-reviewer[bot]`,
-  `coderabbitai[bot]`, `chatgpt-codex-connector[bot]`
+- Advisory bot logins: `copilot-pull-request-reviewer[bot]` only.
+  `coderabbitai[bot]` and `chatgpt-codex-connector[bot]` were dropped
+  2026-08-19 (#115) — across PRs #111-#113 both only ever posted
+  structural non-review notices (Codex: account-level usage-limit
+  exhaustion; CodeRabbit: this repository's star count below its
+  10-star automatic-review threshold), never a real review. Re-add
+  either login via a follow-up issue if the underlying condition
+  clears.
 - Advisory-wait convergence scope: `idd-claimed` (see
   [Helper runtime](#helper-runtime-ephemeral-npx) below for the
   rationale)


### PR DESCRIPTION
## Summary

Drops `coderabbitai[bot]` and `chatgpt-codex-connector[bot]` from
`.github/idd/config.json`'s `advisoryBotLogins`, leaving it exactly
`["copilot-pull-request-reviewer[bot]"]`. Also updates
`docs/idd-policy.md`'s mirrored "Advisory bot logins" bullet, which its
own header requires staying aligned with `.github/idd/config.json`
whenever a value changes.

Closes #115

## Background

Across PRs #111-#113 (2026-08-19 IDD autopilot session), neither bot
ever produced a real review of any HEAD:

- `chatgpt-codex-connector[bot]` posted only an account-level Codex
  usage-limit exhaustion notice, on every single PR.
- `coderabbitai[bot]` posted only its `<10-star automatic-review
  threshold` skip notice, on every single PR.

Both are structurally non-review notices, correctly dispositioned
`**Rejected**` by E4/E6 every time, at the cost of two extra
`gh pr comment` writes per PR. `copilot-pull-request-reviewer[bot]`
stays as this repository's working advisory reviewer under
`reviewPolicy: copilot-advisory`, unaffected by this change.

This is a config value only — it does not touch either app's GitHub
installation or any CodeRabbit/Codex dashboard setting. A follow-up
issue can re-add either login if the underlying condition clears
(Codex's limit resets, or this repository's star count crosses
CodeRabbit's threshold).

## Self-referential note

This PR's own review still runs under the OLD (pre-this-diff)
`advisoryBotLogins` list, since the config only takes effect for later
E-phase triage reading it live — so Codex/CodeRabbit's usual
non-review notices may still appear here and will be dispositioned the
same way as always (per #119/#120).
