### PR TITLE
ci: resync advisory-convergence and post-merge-cleanup to 0.7.0

### DIFF
--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -38,14 +38,14 @@ on:
         required: true
         type: number
       runner:
-        description: Runner label (default ubuntu-slim)
+        description: Runner label (default ubuntu-slim; falls back to
+          the CI_RUNNER_LABEL repository variable, then ubuntu-slim,
+          when left unset)
         required: false
         type: string
-        default: ubuntu-slim
   workflow_call:
     inputs:
       runner:
-        default: ubuntu-slim
         required: false
         type: string
       pr_number:

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -7,44 +7,78 @@ name: IDD advisory-convergence gate
 #
 # This repository adapts the upstream idd-template/ copy of this file to
 # its own ephemeral-npx helper-runtime profile (.github/idd/config.json
-# helperRuntime.profile): runs-on, the checkout step, and the verdict
-# invocation stay on this repo's existing ubuntu-slim / pinned-checkout /
-# npx form (matching idd-doctor.yml) rather than upstream's generic
-# ubuntu-latest + actions/setup-node + `node scripts/advisory-convergence.mjs`
-# form, which assumes a vendored scripts/ directory this repository does
-# not have. See docs/idd-policy.md's "Helper runtime (ephemeral-npx)"
+# helperRuntime.profile): the checkout step and the verdict invocation
+# stay on this repo's existing pinned-checkout / npx form (matching
+# idd-doctor.yml) rather than upstream's generic actions/setup-node +
+# `node scripts/advisory-convergence.mjs` form, which assumes a vendored
+# scripts/ directory this repository does not have. `runs-on` follows
+# upstream's runner-override chain (the `runner` input / `CI_RUNNER_LABEL`
+# variable), defaulting to `ubuntu-slim` to match this repo's own
+# convention. See docs/idd-policy.md's "Helper runtime (ephemeral-npx)"
 # section for the pinned-SHA sync obligation this file participates in.
 concurrency:
   cancel-in-progress: true
-  # Grouped by PR number, not github.ref: pull_request_review and
-  # pull_request_review_comment are not pull_request-family events, so
-  # github.ref does not resolve the same way for them as it does for a
-  # pull_request-only workflow. workflow_dispatch has no pull_request
-  # context either, so it falls back to its own input.
+  # Grouped by PR number, not github.ref: pull_request_review is not a
+  # pull_request-family event, so github.ref does not resolve the same
+  # way for it as it does for a pull_request-only workflow.
+  # Review-thread comments live in the companion
+  # idd-advisory-convergence-comment.yml workflow and must not share
+  # this group. workflow_dispatch has no pull_request context either,
+  # so it falls back to its own input.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
-
 on:
   pull_request:
     types: [opened, reopened, synchronize]
   pull_request_review:
     types: [submitted]
-  pull_request_review_comment:
-    types: [created, edited, deleted]
   workflow_dispatch:
     inputs:
       pr_number:
         description: PR number to re-check (e.g. after posting a maintainer waiver)
         required: true
         type: number
-
+      runner:
+        description: Runner label (default ubuntu-slim)
+        required: false
+        type: string
+        default: ubuntu-slim
+  workflow_call:
+    inputs:
+      runner:
+        default: ubuntu-slim
+        required: false
+        type: string
+      pr_number:
+        description: PR number when this workflow is called without a pull_request event
+        required: true
+        type: number
 permissions:
   contents: read
   issues: read
   pull-requests: read
-
+defaults:
+  run:
+    # Pins every run: step's shell regardless of runner OS -- GitHub
+    # Actions otherwise picks bash on Linux/macOS but PowerShell Core
+    # on Windows, which would silently misinterpret this file's POSIX
+    # shell syntax (e.g. "$PR_NUMBER" as an undefined PowerShell
+    # variable) instead of failing loudly. Available on every
+    # GitHub-hosted runner, including Windows via Git Bash, so this is
+    # a no-op on the runners this template ships for today.
+    shell: bash
 jobs:
+  # The job id `idd-advisory-convergence` is the exact check-run context
+  # consumed by the rerun helper, advisory-wait policy, required status
+  # check, and external-check waiver selector. Adding a `name:` display-name
+  # key or changing the job id changes that literal context. This warning is
+  # preventive; no observed incident yet. If either edit is intentional,
+  # update every consumer to the new literal context together.
   idd-advisory-convergence:
-    runs-on: ubuntu-slim
+    # See the header comment above for the runner / CI_RUNNER_LABEL override.
+    runs-on: ${{ inputs.runner || vars.CI_RUNNER_LABEL || 'ubuntu-slim' }}
+    # Bounds pathological hangs; adjust to your own observed run duration
+    # once you have history (see idd-doctor.yml/lint.yml in the source
+    # repository for the pattern of sizing this from real run durations).
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -73,7 +107,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: >-
           npx --yes --package
-          https://codeload.github.com/kurone-kito/idd-skill/tar.gz/abd841ac0712dec83231ca77096abea67a3497b4
+          https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0
           idd-advisory-convergence
           --pr "$PR_NUMBER"
           --assert

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -80,6 +80,15 @@ permissions:
 concurrency:
   group: post-merge-cleanup-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: false
+defaults:
+  run:
+    # Pins every run: step's shell regardless of runner OS -- GitHub
+    # Actions otherwise picks bash on Linux/macOS but PowerShell Core
+    # on Windows, which would silently misinterpret this file's POSIX
+    # command substitution and shell variable expansion instead of
+    # failing loudly. Available on every GitHub-hosted runner,
+    # including Windows via Git Bash.
+    shell: bash
 jobs:
   cleanup:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
@@ -250,6 +259,8 @@ jobs:
             FAILED=$(printf '%s' "$JSON" | jq -r '(.failed // []) | length')
             SKIPPED=$(printf '%s' "$JSON" | jq -r '(.skipped // []) | length')
             BLOCKED=$(printf '%s' "$JSON" | jq -r '[(.skipped // [])[] | select(.isMinimized==false and .viewerCanMinimize==false)] | length')
+            RETRY_ATTEMPTS=$(printf '%s' "$JSON" | jq -r '.retryAttempts // 0')
+            RETRY_BOUND_EXHAUSTED=$(printf '%s' "$JSON" | jq -r '.retryBoundExhausted // false')
             if [ "$HELPER_EXIT" -ne 0 ]; then
               echo "::warning::audit-pr-cleanup exited $HELPER_EXIT but emitted a valid JSON report; using helper status \"$STATUS\""
             fi
@@ -260,6 +271,8 @@ jobs:
             FAILED=0
             SKIPPED=0
             BLOCKED=0
+            RETRY_ATTEMPTS=0
+            RETRY_BOUND_EXHAUSTED=false
           fi
           {
             echo "pr_number=$PR_NUMBER"
@@ -268,6 +281,8 @@ jobs:
             echo "failed=$FAILED"
             echo "skipped=$SKIPPED"
             echo "blocked=$BLOCKED"
+            echo "retry_attempts=$RETRY_ATTEMPTS"
+            echo "retry_bound_exhausted=$RETRY_BOUND_EXHAUSTED"
           } >> "$GITHUB_OUTPUT"
       - name: Post cleanup evidence comment
         if: steps.profile.outputs.profile != 'instructions-only'
@@ -284,20 +299,27 @@ jobs:
           FAILED: ${{ steps.cleanup.outputs.failed }}
           SKIPPED: ${{ steps.cleanup.outputs.skipped }}
           BLOCKED: ${{ steps.cleanup.outputs.blocked }}
+          RETRY_ATTEMPTS: ${{ steps.cleanup.outputs.retry_attempts }}
+          RETRY_BOUND_EXHAUSTED: ${{ steps.cleanup.outputs.retry_bound_exhausted }}
         run: |
-          # Avoid duplicate evidence comments. Workflow-level concurrency
-          # only serialises this workflow's own runs; an agent F4 (or a
-          # maintainer rerunning workflow_dispatch on the same PR) can
-          # still have posted an evidence comment outside this run. Skip
-          # if a <!-- idd-cleanup-evidence: ... --> comment already on the
-          # PR was posted by a trusted author -- this workflow's own posts
-          # are authored by `github-actions[bot]` (the GITHUB_TOKEN actor),
-          # and an agent's local F4 post is authored by a configured
-          # `trustedMarkerActors` login. An untrusted commenter pre-posting
-          # this marker prefix must never suppress the genuine evidence
-          # post or be treated as a completed cleanup record (this is the
-          # same trust-scoping every other IDD operational marker already
-          # applies).
+          # Avoid duplicate evidence comments, but only on a genuinely
+          # converged outcome. Workflow-level concurrency only serialises
+          # this workflow's own runs; an agent F4 (or a maintainer
+          # rerunning workflow_dispatch on the same PR) can still have
+          # posted an evidence comment outside this run. Skip only when
+          # the latest trusted <!-- idd-cleanup-evidence: {status} ... -->
+          # comment already records `applied` or `clean` -- a trusted
+          # comment recording any other status (`failed`, `incomplete`,
+          # `rescan-failed`, `permission-blocked`) invites a retry, so a
+          # rerun must post fresh evidence for its own outcome instead of
+          # leaving stale non-success evidence as the PR's only record.
+          # "Trusted" scoping: this workflow's own posts are authored by
+          # `github-actions[bot]` (the GITHUB_TOKEN actor), and an agent's
+          # local F4 post is authored by a configured `trustedMarkerActors`
+          # login. An untrusted commenter pre-posting this marker prefix
+          # must never suppress the genuine evidence post or be treated as
+          # a completed cleanup record (this is the same trust-scoping
+          # every other IDD operational marker already applies).
           # This step runs under the default GitHub Actions bash flags
           # (-eo pipefail), so a plain `jq ... .github/idd/config.json`
           # would abort the whole step under `set -e` when the file is
@@ -319,24 +341,31 @@ jobs:
           # empty and post a duplicate evidence comment on a transient
           # `gh api` failure (rate limit/network). A plain command
           # substitution assignment does trip `-e` on failure.
+          #
+          # The API returns issue comments in creation-ascending order, so
+          # iterating every match without an early `break` and keeping the
+          # last assignment leaves EXISTING/EXISTING_STATUS holding the
+          # *latest* trusted comment, not merely the first one found.
           COMMENTS_TSV=$(gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login] | @tsv')
+            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login, (.body | split("\n")[0])] | @tsv')
           EXISTING=""
-          while IFS=$'\t' read -r candidate_id candidate_login; do
+          EXISTING_STATUS=""
+          while IFS=$'\t' read -r candidate_id candidate_login candidate_marker_line; do
             [ -z "$candidate_id" ] && continue
             lower_login=$(printf '%s' "$candidate_login" | tr '[:upper:]' '[:lower:]')
             if printf '%s\n' "$TRUSTED_LOGINS" | grep -Fxq "$lower_login"; then
               EXISTING="$candidate_id"
-              break
+              EXISTING_STATUS=$(printf '%s' "$candidate_marker_line" \
+                | sed -n 's/^<!-- idd-cleanup-evidence: \([^ ]*\) .*/\1/p')
             fi
           done <<< "$COMMENTS_TSV"
-          if [ -n "$EXISTING" ]; then
-            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
+          if [ -n "$EXISTING" ] && { [ "$EXISTING_STATUS" = "applied" ] || [ "$EXISTING_STATUS" = "clean" ]; }; then
+            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment recording '${EXISTING_STATUS}' (id: ${EXISTING}); skipping workflow post."
             exit 0
           fi
-          BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
-            "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} -->" \
+          BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+            "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} retry-attempts:${RETRY_ATTEMPTS} retry-bound-exhausted:${RETRY_BOUND_EXHAUSTED} -->" \
             "**F4 Cleanup Evidence** (server-side fallback via \`post-merge-cleanup.yml\`)" \
             "| Field              | Value |" \
             "| ------------------ | ----- |" \
@@ -345,6 +374,7 @@ jobs:
             "| Failed             | ${FAILED} |" \
             "| Skipped            | ${SKIPPED} |" \
             "| Permission-blocked | ${BLOCKED} |" \
+            "| Retry attempts (bound-exhausted) | ${RETRY_ATTEMPTS} (${RETRY_BOUND_EXHAUSTED}) |" \
             "| Posted by          | post-merge-cleanup workflow |" \
           )
           printf '%s' "$BODY" | gh pr comment "$PR_NUMBER" --body-file -


### PR DESCRIPTION
## Summary

Resyncs `.github/workflows/idd-advisory-convergence.yml` and
`.github/workflows/post-merge-cleanup.yml` to upstream `idd-skill`
`0.7.0` (`f51a8bb73a47452eff5799e8a27251b660ba4ae0`), merging in each
file's substantive upstream changes while preserving this repository's
`ephemeral-npx` helper-runtime adaptation, following the same precedent
issue #87 / PR #94 already established during the 0.6.0 resync.

Closes #118

## What changed

`idd-advisory-convergence.yml`:

- Drops the `pull_request_review_comment` trigger (that event is now
  owned by the companion `idd-advisory-convergence-comment.yml`
  workflow — tracked separately in #128, blocked on an upstream
  bin-export gap, so not added here).
- Adds the `workflow_call` trigger and the `runner` /
  `CI_RUNNER_LABEL` runner-override chain, and `defaults.run.shell:
  bash`.
- Adds the job-id warning comment and updates the concurrency-group
  comment to describe the companion workflow.
- Bumps the pinned `idd-skill` commit embedded in the `npx` invocation
  from `abd841ac` to `f51a8bb7`.
- Preserves this repository's own adapted structure (added at #47):
  the pinned `actions/checkout` SHA, no `actions/setup-node` step, and
  the `npx --package .../idd-advisory-convergence` invocation form —
  rather than upstream's generic `node scripts/advisory-convergence.mjs`
  form, which assumes a vendored `scripts/` directory this repository
  does not have.

`post-merge-cleanup.yml`:

- Takes upstream's body verbatim — the profile-resolution logic
  already resolves `helperRuntime.profile` at runtime and needs no
  local adaptation. This adds the `retryAttempts` /
  `retryBoundExhausted` report fields and the refined
  latest-trusted-comment duplicate-evidence-skip logic (only skips a
  repost when the latest trusted `idd-cleanup-evidence` comment already
  records `applied` or `clean`, rather than any trusted comment).
- Reapplies this repository's hardening from commit `455afe6`:
  `runs-on: ubuntu-slim` (not `ubuntu-latest`) and pinned
  `actions/checkout` / `actions/setup-node` SHAs (not floating `@v4`).

`docs/idd-policy.md` still references the old `abd841ac` SHA in two
places (the "Imported template snapshot" and "Helper runtime" sections)
— intentionally left alone here. #121 records the 0.7.0 resync there
and is sequenced to land after this issue closes.

`.github/workflows/idd-doctor.yml` and `.github/workflows/lint.yml` are
untouched, as scoped.

## Verification

- Diffed both files directly against the upstream bytes fetched from
  `kurone-kito/idd-skill` at `f51a8bb73a47452eff5799e8a27251b660ba4ae0`
  (`idd-template/.github/workflows/`), not just against the prior B2
  planning comment's prose.
- `npx -y markdownlint-cli2 "**/*.md" && npx -y cspell lint "**"
  --no-progress` exits 0.
- Both workflow files parse as valid YAML.
