### PR TITLE
docs: record the idd-skill 0.7.0 resync in docs/idd-policy.md

### DIFF
--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -35,6 +35,26 @@ changes.
   repository's file predates upstream's own copy) rather than a straight
   overwrite. Registering `idd-advisory-convergence` as a required status
   check was reconsidered and declined again.
+- Resynced: `iddVersion 0.7.0`, imported from
+  [`kurone-kito/idd-skill`](https://github.com/kurone-kito/idd-skill)
+  `main` at commit
+  [`f51a8bb73a47452eff5799e8a27251b660ba4ae0`](https://github.com/kurone-kito/idd-skill/commit/f51a8bb73a47452eff5799e8a27251b660ba4ae0)
+  (2026-08-19). `.github/instructions/lite/` remains deliberately
+  excluded, unchanged reasoning from the 0.4.0/0.6.0 entries.
+  `helperRuntime.packageSpec` is re-pinned to the same commit (#119),
+  keeping the `ephemeral-npx` runtime and the distributed instructions
+  in sync; this file's own "Pinned helper package spec" line below
+  moves to match. The two new optional policy fields this release
+  added (`authoringLanguage`, `critiqueLoop.delegate`) were considered
+  and not adopted — no product/design decision favors either yet.
+  Registering `idd-advisory-convergence` as a required status check
+  remains unchanged this cycle; see #114, deferred until this resync's
+  wall-clock-deadline polling fix is confirmed live. The imported
+  workflow surface shipped 2 of the 3 upstream files
+  (`idd-advisory-convergence.yml`, `post-merge-cleanup.yml`); the third
+  (`idd-advisory-convergence-comment.yml`) split out to #128, blocked
+  on an upstream gap — no `ephemeral-npx`-reachable bin export for
+  `scripts/review-comment-origin.mjs` exists in `f51a8bb7`.
 
 ## Project values
 
@@ -169,11 +189,11 @@ add files to this shell-and-Terraform repository and need re-vendoring
 on every upstream bump. `ephemeral-npx` avoids both costs.
 
 - Pinned helper package spec:
-  `https://codeload.github.com/kurone-kito/idd-skill/tar.gz/abd841ac0712dec83231ca77096abea67a3497b4`
+  `https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0`
   — intentionally pinned to the same commit the instruction files were
-  imported from (originally in #41, resynced to this commit in #88), so
-  a helper's JSON output contract can never drift away from the
-  instruction step that reads it.
+  imported from (originally in #41, resynced in #88, resynced to this
+  commit in #119), so a helper's JSON output contract can never drift
+  away from the instruction step that reads it.
 - Canonical invocation form: `npx --yes --package <pinned-spec>
   idd-<helper>`. Under this profile the `idd-*` bin facade is the
   authoritative surface, not `node scripts/*.mjs`.


### PR DESCRIPTION
## Summary

Adds a new "Imported template snapshot" entry to `docs/idd-policy.md`
recording the `idd-skill` `iddVersion 0.7.0` resync (commit
`f51a8bb73a47452eff5799e8a27251b660ba4ae0`, 2026-08-19), following the
exact format of the existing 0.3.0/0.4.0/0.6.0 entries. Also fixes this
same file's own stale "Pinned helper package spec" line, which still
quoted the pre-resync `abd841ac` commit after `.github/idd/config.json`
was already re-pinned to `f51a8bb7` in an earlier roadmap track.

## Closing

Closes #121

## Background

This is the last (finalize) track of the `idd-template-resync-v0-7-0`
roadmap (#122). The four tracks it was blocked by are all
closed/merged: #117 (instruction/docs corpus resync), #118 (CI
workflow resync, scope amended mid-flight — see below), #119
(`iddVersion`/`packageSpec` bump, PR #123), #120 (`issue-authoring`
skill bundle resync).

The new entry records:

- `iddVersion 0.7.0`, commit `f51a8bb73a47452eff5799e8a27251b660ba4ae0`,
  dated `2026-08-19` (the commit's own committer date, matching this
  roadmap's dating convention, not upstream's `2026-08-20`
  `CHANGELOG.md` release-day label).
- `.github/instructions/lite/` remains deliberately excluded, unchanged
  reasoning from the prior entries.
- `authoringLanguage` and `critiqueLoop.delegate` — the two new optional
  policy fields this release added — were considered and not adopted;
  no product/design decision favors either yet.
- The `idd-advisory-convergence` required-status-check question is
  unchanged this cycle; cross-referenced to #114, which stays deferred
  until this resync's wall-clock-deadline polling fix is confirmed
  live.
- The imported workflow surface shipped 2 of the 3 upstream files
  (`idd-advisory-convergence.yml`, `post-merge-cleanup.yml`). The third
  (`idd-advisory-convergence-comment.yml`) was split out of #118's
  original scope to follow-up issue #128 mid-flight, blocked on an
  upstream gap — no `ephemeral-npx`-reachable bin export exists for
  `scripts/review-comment-origin.mjs` in `f51a8bb7` — and is not part
  of this resync's delivered scope.

The secondary fix (the "Pinned helper package spec" line under
"Helper runtime") was explicitly deferred here by PR #123's own body:
"`docs/idd-policy.md`'s two occurrences of the old SHA are deliberately
out of scope here — deferred to #116's Track 5" (this issue). Leaving
it stale would have made the file self-contradictory immediately after
this PR (the new snapshot entry says `f51a8bb7`, while this other line
would still say `abd841ac`).

## Follow-up

None beyond the roadmap's own remaining closure step (#122, tracked by
the orchestrating session — not part of this issue's scope).
