### PR TITLE
docs: record idd-roadmap-audit path divergence as permanent

### DIFF
--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -109,9 +109,11 @@ scripts.
   future template resync must not "fix" it back to the literal
   upstream path. That same file's `{{PROJECT_MARKER_PREFIX}}` token
   (an installed instruction file, not reusable template
-  documentation) is unrelated: it is ordinary substitution to
-  `setup-ubuntu`, not a second divergence. This does not extend to
-  every `{{PROJECT_MARKER_PREFIX}}` occurrence repository-wide —
+  documentation) is unrelated: it resolves to the literal prefix
+  `setup-ubuntu`, used as `setup-ubuntu-roadmap-id`, the same ordinary
+  substitution as every other installed instruction file — not a
+  second divergence. This does not extend to every
+  `{{PROJECT_MARKER_PREFIX}}` occurrence repository-wide —
   reusable template documentation such as
   `docs/onboarding/placeholders.md` and `docs/customization.md`
   deliberately keeps the literal placeholder as reference text and

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -100,6 +100,17 @@ scripts.
   source layout by #44; a future template resync must copy the
   upstream bundle to that same installed path, not the pre-#44
   location)
+- `idd-roadmap-audit.instructions.md`'s contract-path reference
+  intentionally points at that same installed
+  `.claude/skills/issue-authoring/references/contract.md` location,
+  not upstream `idd-template/`'s generic
+  `skills/issue-authoring/references/contract.md` example path (#125).
+  This is a **permanent, intentional divergence** from upstream — a
+  future template resync must not "fix" it back to the literal
+  upstream path. The same file's `{{PROJECT_MARKER_PREFIX}}` token is
+  unrelated: it resolves normally to `setup-ubuntu` like every other
+  occurrence of that token in this repository, not a second
+  divergence.
 - Helper runtime profile: `ephemeral-npx` (see
   [Helper runtime](#helper-runtime-ephemeral-npx) below)
 - Advisory bot logins: `copilot-pull-request-reviewer[bot]` only.

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -100,17 +100,22 @@ scripts.
   source layout by #44; a future template resync must copy the
   upstream bundle to that same installed path, not the pre-#44
   location)
-- `idd-roadmap-audit.instructions.md`'s contract-path reference
-  intentionally points at that same installed
+- `.github/instructions/idd-roadmap-audit.instructions.md`'s
+  contract-path reference intentionally points at that same installed
   `.claude/skills/issue-authoring/references/contract.md` location,
   not upstream `idd-template/`'s generic
   `skills/issue-authoring/references/contract.md` example path (#125).
   This is a **permanent, intentional divergence** from upstream — a
   future template resync must not "fix" it back to the literal
-  upstream path. The same file's `{{PROJECT_MARKER_PREFIX}}` token is
-  unrelated: it resolves normally to `setup-ubuntu` like every other
-  occurrence of that token in this repository, not a second
-  divergence.
+  upstream path. That same file's `{{PROJECT_MARKER_PREFIX}}` token
+  (an installed instruction file, not reusable template
+  documentation) is unrelated: it is ordinary substitution to
+  `setup-ubuntu`, not a second divergence. This does not extend to
+  every `{{PROJECT_MARKER_PREFIX}}` occurrence repository-wide —
+  reusable template documentation such as
+  `docs/onboarding/placeholders.md` and `docs/customization.md`
+  deliberately keeps the literal placeholder as reference text and
+  must stay unsubstituted.
 - Helper runtime profile: `ephemeral-npx` (see
   [Helper runtime](#helper-runtime-ephemeral-npx) below)
 - Advisory bot logins: `copilot-pull-request-reviewer[bot]` only.


### PR DESCRIPTION
## Summary

- Records, in `docs/idd-policy.md`, that `idd-roadmap-audit.instructions.md`'s
  contract-path reference intentionally points at this repository's
  installed `.claude/skills/issue-authoring/references/contract.md`
  location rather than upstream `idd-template/`'s generic
  `skills/issue-authoring/references/contract.md` example path — a
  permanent divergence a future template resync must not "fix" back.
- No edit to `.github/instructions/idd-roadmap-audit.instructions.md`
  itself: a fresh diff against upstream `idd-skill` at
  `f51a8bb73a47452eff5799e8a27251b660ba4ae0` confirms the file already
  matches the maintainer's decided target state — the
  `{{PROJECT_MARKER_PREFIX}}` token already resolves to
  `setup-ubuntu-roadmap-id` (ordinary substitution, same as #117's
  sibling-file resolutions), and the path is already the local one.
  This satisfies the issue's own acceptance criterion: "The file is
  updated (or explicitly left as-is with the decision recorded) to
  match that decision."

Closes #125

## Background

Follow-up from roadmap #122 (`idd-template-resync-v0-7-0`): while
resyncing the IDD instruction corpus, #117 found that this file
diverges from upstream in two spots and flagged it for a maintainer
decision rather than a mechanical fix, since one divergence (the path)
looked intentional — upstream's generic example path does not exist in
this repository. The maintainer selected option (a): resolve the
token the same way #117 resolved it elsewhere, keep the local path
correction, and record the intentional divergence. Verification during
this PR (re-diffing against upstream) showed the token side of that
decision was already satisfied locally, so this PR only adds the
documentation half.

## Test plan

- [x] `npx -y markdownlint-cli2 --fix "**/*.md" && npx -y markdownlint-cli2 "**/*.md"` (fix-validate)
- [x] `npx -y markdownlint-cli2 "**/*.md" && npx -y cspell lint "**" --no-progress` (pre-push-validate)
- [x] Byte-diffed `.github/instructions/idd-roadmap-audit.instructions.md`
      against upstream `f51a8bb73a47452eff5799e8a27251b660ba4ae0`: exactly
      two hunks remain (the `{{PROJECT_MARKER_PREFIX}}` token, ordinary
      substitution; the contract-path reference, now documented as
      intentional) and a `{{[A-Z_]+}}` token grep on the local file finds
      none.
