### PR TITLE
feat: install the CodeRabbit CLI via the vendor install script

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -107,6 +107,7 @@ mise 設定に移管されました。移管先の一覧や層構造について
 
 #### 生成 AI
 
+- [CodeRabbit CLI](https://docs.coderabbit.ai/cli/overview)
 - (B) [Ollama](https://ollama.com/)
 
 ### ハードウェア

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ fresh shell, after `./setup`) is what installs those handed-off CLIs.
 
 #### Generative AI
 
+- [CodeRabbit CLI](https://docs.coderabbit.ai/cli/overview)
 - (B) [Ollama](https://ollama.com/)
 
 ### Hardware

--- a/lib/coderabbit.sh
+++ b/lib/coderabbit.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# -*- mode: sh -*-
+# vim: set ft=sh :
+
+set -eu
+cd "$(cd "$(dirname "$0")"; pwd)/.."
+
+# Download to a temp file first: `curl ... | sh -` would let a failed
+# curl exit the pipeline at 0 (sh runs on an empty stdin), silently
+# skipping the install instead of failing this stage.
+installer="$(mktemp)"
+trap 'rm -f "$installer"' EXIT
+curl -fsSL https://cli.coderabbit.ai/install.sh -o "$installer"
+
+# CI=1 is scoped to this one invocation only (not exported for the rest
+# of this script): it makes the installer skip its interactive
+# post-install "Start browser sign-in now? [Y/n]" prompt, which
+# otherwise blocks on stdin during a non-interactive setup run.
+CI=1 sh "$installer"

--- a/setup
+++ b/setup
@@ -161,9 +161,12 @@ run_stage lib/unity.sh
 # lib/unity.sh installs the CLI to ~/.local/bin as a separate process, so
 # the vendor installer's own PATH edit (to ~/.bashrc, read by future
 # shells) never reaches this already-running script. Add it here so
-# lib/unity-editors.sh can find `unity` within this same setup run.
+# lib/unity-editors.sh can find `unity` within this same setup run, and
+# so lib/coderabbit.sh's own installer sees ~/.local/bin already on PATH
+# and skips its own ~/.bashrc edit (chezmoi/dotfiles manage that file).
 PATH="${HOME}/.local/bin:${PATH}"
 export PATH
+run_stage lib/coderabbit.sh
 run_stage lib/teardown.sh
 run_stage lib/locale.sh
 


### PR DESCRIPTION
## Summary

Adds `lib/coderabbit.sh`, installing the CodeRabbit CLI (`coderabbit` /
`cr`) through its official vendor install script, following the same
temp-file-download-then-execute pattern already used by `lib/unity.sh`
for another vendor-script-installed CLI. Wires the new stage into
`setup` and lists the tool in both README files' "Generative AI"
section.

- `lib/coderabbit.sh`: downloads `https://cli.coderabbit.ai/install.sh`
  to a `mktemp` file (cleaned up via `trap ... EXIT`) rather than piping
  `curl | sh` directly, then runs it with `CI=1` scoped to that one
  child invocation only — this makes the installer skip its interactive
  post-install "Start browser sign-in now? [Y/n]" prompt, which
  otherwise blocks on stdin during a non-interactive `./setup` run.
- `setup`: adds `run_stage lib/coderabbit.sh` after the existing
  `PATH="${HOME}/.local/bin:${PATH}"` export (added for `lib/unity.sh`)
  and before `run_stage lib/teardown.sh`. Placing it after that export
  also makes the CodeRabbit installer's own `check_path` succeed, so it
  skips its own `~/.bashrc` PATH edit (which chezmoi/dotfiles otherwise
  manage).
- `README.md` / `README.ja.md`: add an unmarked CodeRabbit CLI entry
  (no `(B)`/`(M)` note, matching the Unity CLI entry) next to Ollama.

Homebrew was not used: `brew install coderabbit` resolves to a
macOS-only cask (`formulae.brew.sh/cask/coderabbit`), and this
repository's `lib/Brewfile` explicitly forbids `cask` stanzas
(formulae only).

## Background / rationale

The vendor installer performs no checksum or GPG signature
verification of the downloaded binary — it only downloads a zip and
extracts it. This is a known, pre-existing limitation shared verbatim
with `lib/unity.sh`'s identical vendor-installer pattern (also
unverified), not something introduced by this PR; issue #134's own
Background records this as an accepted tradeoff, matching the existing
precedent rather than opening a new one.

Self-review (a backgrounded high-effort `/code-review` pass across
eight finder angles, each candidate independently re-verified) surfaced
one additional, related observation worth recording rather than fixing
here: `curl -fsSL` reliably fails on a bad HTTP status or a violated
Content-Length/chunked frame, but a rare connection-close-delimited
truncated response could in theory still leave curl at exit 0 with an
empty/garbage installer file, which `sh` would then also run
successfully — silently marking the `run_stage` complete without
actually installing anything. This is the exact same exposure
`lib/unity.sh` already carries (identical code shape, in production for
months with no reported incident), so fixing it only in
`lib/coderabbit.sh` would fork the two scripts and re-litigate a
decision issue #134 already made when it named the unity.sh precedent.
Not a clear-cut defect given that shared history, but real enough to be
worth a follow-up issue covering download-integrity verification for
both vendor-installer scripts together, if the maintainer wants one.

The review's other candidate (boilerplate duplication between
`lib/coderabbit.sh` and `lib/unity.sh`) was also left as-is: every
`lib/*.sh` in this repository is an intentional standalone stage
script, and a shared-helper extraction across a two-line-file pattern
would be a premature abstraction — the same optional follow-up above
could fold in a shared `download-and-run-installer` helper if the
integrity-check follow-up is ever picked up.

## Verification performed

- `shellcheck lib/coderabbit.sh` / `shellcheck setup` / `shellcheck
  lib/*.sh`: clean
- `npx markdownlint-cli2 "**/*.md"`: 0 issues
- `npx cspell lint "**" --no-progress`: 0 issues (`coderabbit` passes
  via `allowCompoundWords`, no dictionary change needed)
- `./tests/setup-cli.test.sh`: all cases pass (this change does not
  touch the `setup` CLI argument surface)
- **Live end-to-end test on this real Ubuntu host** (not CI — Actions
  status was uncertain at authoring time): ran `lib/coderabbit.sh
  </dev/null` with `~/.local/bin` pre-exported on `PATH`, twice
  (idempotency check). Both runs completed non-interactively without
  blocking on the sign-in prompt; `coderabbit --version` exited 0
  (`0.7.5`), the `cr` symlink resolved to the installed binary, and
  `~/.bashrc` was left untouched (PATH already present, so the
  installer's own edit path never triggered).

Closes #134
